### PR TITLE
Add in html report the image of correlation matrix

### DIFF
--- a/pandas_profiling/templates.py
+++ b/pandas_profiling/templates.py
@@ -23,7 +23,8 @@ templates = {'freq_table_row': 'freq_table_row.html',
              'overview': 'overview.html',
              'sample': 'sample.html',
              'base': 'base.html',
-             'wrapper': 'wrapper.html'
+             'wrapper': 'wrapper.html',
+             'correlations' : 'correlations.html'
              }
 
 # Mapping between row type and var type

--- a/pandas_profiling/templates/correlations.html
+++ b/pandas_profiling/templates/correlations.html
@@ -1,0 +1,5 @@
+<div class="col-md-3 collapse in" id="correlations{{ values['varid'] }}">
+    <img src="{{ values['pearson'] }}">
+    <img src="{{ values['spearman'] }}">
+
+</div>


### PR DESCRIPTION
I tried to add in the html report the images of the correlation matrices (Pearson and Spearman).
The matrix are created in the description result of a data frame, but the integration to the html report doesn't work. Any error is returned.

Here is any example
import pandas as pd                    
import pandas_profiling as pp
import numpy as np
df = pd.DataFrame(np.random.randn(9000).reshape(300,30))
describe_df = pp.describe(df) # works fine

profile = pp.ProfileReport(df)
profile.to_file(outputfile="test.html") # no image in test.html

I am not very comfortable with the template system used here. I am sure I am not far to succeed. Does anyone have any idea how to solve this problem ?
Thanks