### PR TITLE
Use feature detection instead of version detection

### DIFF
--- a/pandas_profiling/report.py
+++ b/pandas_profiling/report.py
@@ -51,10 +51,11 @@ def to_html(sample, stats_object):
         elif isinstance(value, float):
             return value_formatters[formatters.DEFAULT_FLOAT_FORMATTER](value)
         else:
-            if sys.version_info.major == 3:
-                return str(value)
-            else:
-                return unicode(value)
+            try:
+                return unicode(value)  # Python 2
+            except NameError:
+                return str(value)      # Python 3
+                
 
     def _format_row(freq, label, max_freq, row_template, n, extra_class=''):
             width = int(freq / max_freq * 99) + 1


### PR DESCRIPTION
https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection

__unicode()__ was removed from Python 3 because all strs are Unicode.