### PR TITLE
Updated Readme  "conda install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can install using the pip package manager by running
 
 You can install using the conda package manager by running
 
-    conda install pandas-profiling
+    conda install -c anaconda pandas-profiling
 
 ### From source
 


### PR DESCRIPTION
`conda install pandas-profiling` command installs pandas-profiling from the conda-forge channel by default if it is added to the available channels. That version fails to import. At least for now let's specify the correct channel explicitly until the version in conda forge is synced and fixed.