### PR TITLE
Plots with target issue#10

### DIFF
--- a/pandas_profiling/__init__.py
+++ b/pandas_profiling/__init__.py
@@ -61,6 +61,10 @@ class ProfileReport(object):
     def __init__(self, df, **kwargs):
         """Constructor see class documentation
         """
+
+        if ("target_name" in kwargs.keys()):
+            kwargs['target_series'] = df[kwargs['target_name']]
+
         sample = kwargs.get('sample', df.head())
 
         description_set = describe_df(df, **kwargs)
@@ -101,7 +105,7 @@ class ProfileReport(object):
         result = []
         if hasattr(variable_profile, 'correlation'):
             result = variable_profile.index[variable_profile.correlation > threshold].tolist()
-        return  result
+        return result
 
     def to_file(self, outputfile=DEFAULT_OUTPUTFILE):
         """Write the report to a file.

--- a/pandas_profiling/describe.py
+++ b/pandas_profiling/describe.py
@@ -310,6 +310,9 @@ def describe(df, bins=10, check_correlation=True, correlation_threshold=0.9, cor
     pool_size : int
         Number of workers in thread pool
         The default is equal to the number of CPU.
+    target_name : str
+        Name of the target column to plot.
+        By default nothing will be plotted.
 
     Returns
     -------

--- a/pandas_profiling/formatters.py
+++ b/pandas_profiling/formatters.py
@@ -9,7 +9,7 @@ DEFAULT_FLOAT_FORMATTER = u'pandas_profiling.__default_float_formatter'
 def gradient_format(value, limit1, limit2, c1, c2):
     def LerpColour(c1,c2,t):
         return (int(c1[0]+(c2[0]-c1[0])*t),int(c1[1]+(c2[1]-c1[1])*t),int(c1[2]+(c2[2]-c1[2])*t))
-    c = LerpColour(c1, c2, (value-limit1)/(limit2-limit1))
+    c = LerpColour(c1, c2, float(value-limit1)/(limit2-limit1))
     return fmt_color(value,"rgb{}".format(str(c)))
 
 

--- a/pandas_profiling/plot.py
+++ b/pandas_profiling/plot.py
@@ -4,6 +4,7 @@
 import base64
 from distutils.version import LooseVersion
 import pandas_profiling.base as base
+from matplotlib import pyplot as plt
 import matplotlib
 import numpy as np
 # Fix #68, this call is not needed and brings side effects in some use cases
@@ -13,7 +14,7 @@ BACKEND = matplotlib.get_backend()
 if matplotlib.get_backend().lower() != BACKEND.lower():
     # If backend is not set properly a call to describe will hang
     matplotlib.use(BACKEND)
-from matplotlib import pyplot as plt
+
 try:
     from StringIO import BytesIO
 except ImportError:
@@ -23,7 +24,7 @@ try:
 except ImportError:
     from urllib.parse import quote
 
-def _plot_histogram(series, bins=10, figsize=(6, 4), facecolor='#337ab7'):
+def _plot_histogram(series, bins=10, figsize=(6, 4), facecolor='#337ab7', **kwargs):
     """Plot an histogram from the data and return the AxesSubplot object.
 
     Parameters
@@ -40,6 +41,14 @@ def _plot_histogram(series, bins=10, figsize=(6, 4), facecolor='#337ab7'):
     matplotlib.AxesSubplot
         The plot.
     """
+
+    if "target_series" in kwargs.keys():
+        target_series = kwargs["target_series"]
+        is_target = True
+    else :
+        is_target = False
+        target_series = None
+
     if base.get_vartype(series) == base.TYPE_DATE:
         # TODO: These calls should be merged
         fig = plt.figure(figsize=figsize)
@@ -49,11 +58,35 @@ def _plot_histogram(series, bins=10, figsize=(6, 4), facecolor='#337ab7'):
             plot.hist(series.dropna().values, facecolor=facecolor, bins=bins)
         except TypeError: # matplotlib 1.4 can't plot dates so will show empty plot instead
             pass
+        return plot
     else:
-        plot = series.plot(kind='hist', figsize=figsize,
+
+        if is_target:
+            non_null_series = series[~series.isnull()]
+            bins_limit = np.histogram(non_null_series, bins)[1]
+            
+            fig, ax1 = plt.subplots(figsize=figsize)
+            ax1.set_ylabel('Frequency', color=facecolor)
+            avg_target = []
+            avg_bins = []
+
+            for min_, max_ in [(bins_limit[i], bins_limit[i+1]) for i in xrange(len(bins_limit)-1)]:
+                mask = (series >= min_) & (series <= max_) # create bin mask
+                avg_target.append(target_series[mask].mean()) # get mean of elements in bin
+                avg_bins.append(float(min_+max_) / 2) # center of the bin
+            ax1.hist(non_null_series, bins=bins)
+
+            ax2 = ax1.twinx()
+            ax2.plot(avg_bins, avg_target, '-o', color='#fcab10')
+            ax2.set_ylabel('Averaged_%s'%(kwargs['target_name']), color='#fcab10')
+            ax2.grid(False)
+            return fig.get_axes()[1]
+        else:
+            plot = series.plot(kind='hist', figsize=figsize,
                            facecolor=facecolor,
                            bins=bins)  # TODO when running on server, send this off to a different thread
-    return plot
+            return plot
+
 
 
 def histogram(series, **kwargs):
@@ -71,7 +104,10 @@ def histogram(series, **kwargs):
     """
     imgdata = BytesIO()
     plot = _plot_histogram(series, **kwargs)
-    plot.figure.subplots_adjust(left=0.15, right=0.95, top=0.9, bottom=0.1, wspace=0, hspace=0)
+    if 'target_name' in kwargs.keys():
+        plot.figure.subplots_adjust(left=0.15, right=0.85, top=0.9, bottom=0.1, wspace=0, hspace=0)
+    else :
+        plot.figure.subplots_adjust(left=0.15, right=0.95, top=0.9, bottom=0.1, wspace=0, hspace=0)
     plot.figure.savefig(imgdata)
     imgdata.seek(0)
     result_string = 'data:image/png;base64,' + quote(base64.b64encode(imgdata.getvalue()))
@@ -95,6 +131,13 @@ def mini_histogram(series, **kwargs):
     """
     imgdata = BytesIO()
     plot = _plot_histogram(series, figsize=(2, 0.75), **kwargs)
+    if 'target_name' in kwargs.keys():
+        for ax in plot.figure.get_axes():
+            ax.grid(False)
+            ax.get_yaxis().set_visible(False)
+            ax.get_xaxis().set_visible(False)
+            ax.facecolor = 'white'
+
     plot.axes.get_yaxis().set_visible(False)
 
     if LooseVersion(matplotlib.__version__) <= '1.5.9':
@@ -109,6 +152,7 @@ def mini_histogram(series, **kwargs):
     for tick in (xticks[0], xticks[-1]):
         tick.label.set_fontsize(8)
     plot.figure.subplots_adjust(left=0.15, right=0.85, top=1, bottom=0.35, wspace=0, hspace=0)
+
     plot.figure.savefig(imgdata)
     imgdata.seek(0)
     result_string = 'data:image/png;base64,' + quote(base64.b64encode(imgdata.getvalue()))

--- a/pandas_profiling/report.py
+++ b/pandas_profiling/report.py
@@ -55,11 +55,11 @@ def to_html(sample, stats_object):
                 return unicode(value)  # Python 2
             except NameError:
                 return str(value)      # Python 3
-                
+
 
     def _format_row(freq, label, max_freq, row_template, n, extra_class=''):
             if max_freq != 0:
-                width = int(freq / max_freq * 99) + 1
+                width = int(float(freq) / max_freq * 99) + 1
             else:
                 width = 1
 
@@ -73,7 +73,7 @@ def to_html(sample, stats_object):
             return row_template.render(label=label,
                                        width=width,
                                        count=freq,
-                                       percentage='{:2.1f}'.format(freq / n * 100),
+                                       percentage='{:2.1f}'.format(float(freq) / n * 100),
                                        extra_class=extra_class,
                                        label_in_bar=label_in_bar,
                                        label_after_bar=label_after_bar)
@@ -151,9 +151,9 @@ def to_html(sample, stats_object):
 
         if row['type'] in {'CAT', 'BOOL'}:
             formatted_values['minifreqtable'] = freq_table(stats_object['freq'][idx], n_obs,
-                                                           templates.template('mini_freq_table'), 
-                                                           templates.template('mini_freq_table_row'), 
-                                                           3, 
+                                                           templates.template('mini_freq_table'),
+                                                           templates.template('mini_freq_table_row'),
+                                                           3,
                                                            templates.mini_freq_table_nb_col[row['type']])
 
             if row['distinct_count'] > 50:


### PR DESCRIPTION

![pdpf_target_example](https://user-images.githubusercontent.com/12525461/40926815-772116a0-681d-11e8-8008-46795bd3a7f9.png)
This code implements the possibility of specifying a target variable when launching a ProfileReport only by specifying target_name = "the_target_column_name". The average value of this target is then plotted on every bins of the histograms. This can help to recognize obvious patterns and correlations only by looking at pandas-profilling results.

This implementation is what I had in mind when I created the issue #10 a long time ago.
I tried to made the changes as minimal as possible. I hope this could finally close this issue!

I also made some changes so that this version is python2 friendly by adding some float() in the current code.

There is still room for improvement in the final visualization but I feel like this could still be very useful for users without any extra cost (if you don't specify a target nothing changes). Let me known if you think that there are improvements that I could do in order to close issue #10.

Thanks!