### PR TITLE
Fix matplotlib backend issue with python 3.6

### DIFF
--- a/pandas_profiling/plot.py
+++ b/pandas_profiling/plot.py
@@ -9,7 +9,7 @@ import numpy as np
 # Fix #68, this call is not needed and brings side effects in some use cases
 # Backend name specifications are not case-sensitive; e.g., ‘GTKAgg’ and ‘gtkagg’ are equivalent.
 # See https://matplotlib.org/faq/usage_faq.html#what-is-a-backend
-BACKEND = 'Agg'
+BACKEND = matplotlib.get_backend()
 if matplotlib.get_backend().lower() != BACKEND.lower():
     # If backend is not set properly a call to describe will hang
     matplotlib.use(BACKEND)


### PR DESCRIPTION
Keep receiving matplotlib.use(BACKEND) issue. Change the backend by dynamic setting by using `matplotlib.get_backend()`. This PR is also related to a known issue #119 