### PR TITLE
fix recoded test with optional check_recoded flag

### DIFF
--- a/pandas_profiling/tests.py
+++ b/pandas_profiling/tests.py
@@ -273,7 +273,7 @@ class CategoricalDataTest(unittest.TestCase):
              'y': ['dog', 'dog', 'dog', 'dog', 'cat', 'cat', 'camel', 'camel'],
            }
         self.df = pd.DataFrame(self.data)
-        self.results = describe(self.df)
+        self.results = describe(self.df, check_recoded=True)
 
         self.assertEqual(self.results['variables'].loc['x']['type'], 'RECODED')
         self.assertEqual(


### PR DESCRIPTION
This is needed for the CategoricalDataTest to pass.