### PR TITLE
Warn about interactive matplotlib causing hangs

### DIFF
--- a/pandas_profiling/describe.py
+++ b/pandas_profiling/describe.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 import matplotlib
 
-from pkg_resources import resource_filename
 import pandas_profiling.formatters as formatters
 import pandas_profiling.base as base
 from pandas_profiling.plot import histogram, mini_histogram
@@ -328,15 +327,6 @@ def describe(df, bins=10, check_correlation=True, correlation_threshold=0.9, cor
         raise TypeError("df must be of type pandas.DataFrame")
     if df.empty:
         raise ValueError("df can not be empty")
-
-    try:
-        # reset matplotlib style before use
-        # Fails in matplotlib 1.4.x so plot might look bad
-        matplotlib.style.use("default")
-    except:
-        pass
-
-    matplotlib.style.use(resource_filename(__name__, "pandas_profiling.mplstyle"))
 
     # Clearing the cache before computing stats
     base.clear_cache()

--- a/pandas_profiling/plot.py
+++ b/pandas_profiling/plot.py
@@ -4,15 +4,21 @@
 import base64
 from distutils.version import LooseVersion
 import pandas_profiling.base as base
-import matplotlib
 import numpy as np
-# Fix #68, this call is not needed and brings side effects in some use cases
-# Backend name specifications are not case-sensitive; e.g., ‘GTKAgg’ and ‘gtkagg’ are equivalent.
-# See https://matplotlib.org/faq/usage_faq.html#what-is-a-backend
-BACKEND = matplotlib.get_backend()
-if matplotlib.get_backend().lower() != BACKEND.lower():
-    # If backend is not set properly a call to describe will hang
-    matplotlib.use(BACKEND)
+import warnings
+import matplotlib
+# style usage: https://stackoverflow.com/a/50218526/
+import matplotlib.style
+from pkg_resources import resource_filename
+matplotlib.style.use(resource_filename(__name__, "pandas_profiling.mplstyle"))
+# The backend cannot be interactive if processing is parallel
+# because of pickling issues https://stackoverflow.com/a/15578386/
+# list of non-interactive backends taken from:
+# https://matplotlib.org/tutorials/introductory/usage.html#backends
+if matplotlib.get_backend().lower() in [b.lower() for b in matplotlib.rcsetup.interactive_bk]:
+    warnings.warn('Interactive Matplotlib backend (%s) will hang when run in parallel'
+                  % matplotlib.get_backend(), RuntimeWarning)
+
 from matplotlib import pyplot as plt
 try:
     from StringIO import BytesIO


### PR DESCRIPTION
Another shot at issue #68 where matplotlib and multiprocessing don't play nice. 

Also moves plotting functions into plot.py and simplifies matplotlib style use (compatible with 1.4 and 3).