### PR TITLE
rare error fix

### DIFF
--- a/pandas_profiling/base.py
+++ b/pandas_profiling/base.py
@@ -45,7 +45,7 @@ def get_groupby_statistic(data):
         return _VALUE_COUNTS_MEMO[data.name]
 
     value_counts_with_nan = data.value_counts(dropna=False)
-    value_counts_without_nan = value_counts_with_nan.loc[value_counts_with_nan.index.dropna()]
+    value_counts_without_nan = pd.Series(value_counts_with_nan.reset_index().dropna().set_index('index'))
     distinct_count_with_nan = value_counts_with_nan.count()
 
     # When the inferred type of the index is just "mixed" probably the types within the series are tuple, dict, list and so on...

--- a/pandas_profiling/base.py
+++ b/pandas_profiling/base.py
@@ -45,7 +45,7 @@ def get_groupby_statistic(data):
         return _VALUE_COUNTS_MEMO[data.name]
 
     value_counts_with_nan = data.value_counts(dropna=False)
-    value_counts_without_nan = pd.Series(value_counts_with_nan.reset_index().dropna().set_index('index'))
+    value_counts_without_nan = value_counts_with_nan.reset_index().dropna().set_index('index').iloc[:,0]
     distinct_count_with_nan = value_counts_with_nan.count()
 
     # When the inferred type of the index is just "mixed" probably the types within the series are tuple, dict, list and so on...


### PR DESCRIPTION
if the only unique not-nan value is False in a column

```python
base.get_groupby_statistic(data)
```
returns

```python
[Series([], Name: isVideoAd, dtype: int64), 2]
```
so afterwards 
`describe_1d` returns 
```python
IndexError: index 0 is out of bounds for axis 0 with size 0
```

as the series is empty. this is one line of code to fix, which is in the pull request.

as the original line returns a simple value of False, that leaves the Series empty because of how .loc works. this way the returned series cannot be empty.