### PR TITLE
Fixed wrong NaT hist bins in plot.py

### DIFF
--- a/pandas_profiling/plot.py
+++ b/pandas_profiling/plot.py
@@ -46,7 +46,7 @@ def _plot_histogram(series, bins=10, figsize=(6, 4), facecolor='#337ab7'):
         plot = fig.add_subplot(111)
         plot.set_ylabel('Frequency')
         try:
-            plot.hist(series.values, facecolor=facecolor, bins=bins)
+            plot.hist(series.dropna().values, facecolor=facecolor, bins=bins)
         except TypeError: # matplotlib 1.4 can't plot dates so will show empty plot instead
             pass
     else:


### PR DESCRIPTION
A simple fix to the problem when NaT values in a dataframe result in having histogram bins for year 1680. 
This makes the histogram very uninformative. 
After the fix, only proper datetime values contribute to all the time histograms.