### PR TITLE
correlation_html -> correlations_html

### DIFF
--- a/pandas_profiling/templates/base.html
+++ b/pandas_profiling/templates/base.html
@@ -226,7 +226,7 @@
     <div class="row headerrow highlight">
         <h1>Correlations</h1>
     </div>
-    {{ correlation_html }}
+    {{ correlations_html }}
     <div class="row headerrow highlight">
         <h1>Sample</h1>
     </div>


### PR DESCRIPTION
This is fix for show "Correlations" section in result.

In report.py at line 207.

`render_htmls['correlations_html'] = correlations_html`

But, in base.html written '{{ correlation_html }}'