### PR TITLE
Recommend conda-forge channel instead of anaconda

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Alternatively, you could install directly from Github:
  
 You can install using the conda package manager by running
 
-    conda install -c anaconda pandas-profiling
+    conda install -c conda-forge pandas-profiling
 
 ### From source
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,7 @@ The pandas <code>df.describe()</code> function is great but a little basic for s
 <p><a href="https://anaconda.org/conda-forge/pandas-profiling/"><img alt="Conda Downloads" src="https://anaconda.org/conda-forge/pandas-profiling/badges/downloads.svg"></a>
 <a href="https://anaconda.org/conda-forge/pandas-profiling"><img alt="Conda Version" src="https://img.shields.io/conda/vn/conda-forge/pandas-profiling.svg"></a> </p>
 <p>You can install using the conda package manager by running</p>
-<pre><code>conda install -c anaconda pandas-profiling
+<pre><code>conda install -c conda-forge pandas-profiling
 </code></pre>
 <h3 id="from-source">From source</h3>
 <p>Download the source code by cloning the repository or by pressing <a href="https://github.com/pandas-profiling/pandas-profiling/archive/master.zip">'Download ZIP'</a> on this page.


### PR DESCRIPTION
Current code block recommends users to install from the anaconda channel, which currently hosts [version 1.4.1](https://anaconda.org/anaconda/pandas-profiling) of the package. Up-to-date version of the package is available on the [conda-forge](https://anaconda.org/conda-forge/pandas-profiling) channel.