### PR TITLE
Abnormal analyzer upgrade1

### DIFF
--- a/pandas_profiling/config_default.yaml
+++ b/pandas_profiling/config_default.yaml
@@ -15,9 +15,11 @@ vars:
     num:
           quantiles:
                 - 0.05
+                - 0.1
                 - 0.25
                 - 0.5
                 - 0.75
+                - 0.9
                 - 0.95
           skewness_threshold: 20
     cat:
@@ -29,6 +31,10 @@ low_categorical_threshold: 5
 
 # Settings regarding warnings
 cardinality_threshold: 50
+
+# Settings for abnormal values warnings
+smallest_abnormal_difference: 2
+largest_abnormal_difference: 2
 
 # which diagrams to show
 missing_diagrams:

--- a/pandas_profiling/config_default.yaml
+++ b/pandas_profiling/config_default.yaml
@@ -33,8 +33,10 @@ low_categorical_threshold: 5
 cardinality_threshold: 50
 
 # Settings for abnormal values warnings
+check_abnormal_values: True
 smallest_abnormal_difference: 2
 largest_abnormal_difference: 2
+abnormal_threshold_difference: 0.2
 
 # which diagrams to show
 missing_diagrams:

--- a/pandas_profiling/model/messages.py
+++ b/pandas_profiling/model/messages.py
@@ -139,24 +139,45 @@ def check_variable_messages(col: str, description: dict) -> List[Message]:
                     column_name=col, message_type=MessageType.ZEROS, values=description
                 )
             )
-        # abnormally smallest values
-        if ((description["5%"] - description["min"]) / (description["10%"] - description["5%"])) > config["smallest_abnormal_difference"].get():
-            messages.append(
-                Message(
-                    column_name=col,
-                    message_type=MessageType.SMALLEST_ABNORMAL,
-                    values=description,
+        if config["check_abnormal_values"].get():
+            # abnormally smallest values check
+            P10_5 = description["10%"] - description["5%"]
+            if P10_5 != 0:
+                if ((description["5%"] - description["min"]) / P10_5) > config["smallest_abnormal_difference"].get():
+                    messages.append(
+                        Message(
+                            column_name=col,
+                            message_type=MessageType.SMALLEST_ABNORMAL,
+                            values=description,
+                        )
+                    )
+            elif ((description["5%"] - description["min"]) / (description["max"] - description["min"])) > config["abnormal_threshold_difference"].get():
+                    messages.append(
+                        Message(
+                            column_name=col,
+                            message_type=MessageType.SMALLEST_ABNORMAL,
+                            values=description,
+                        )
+                    )
+            # abnormally largest values check
+            P95_90 = description["95%"] - description["90%"]
+            if P95_90 != 0:
+                if ((description["max"] - description["95%"]) / P95_90) > config["largest_abnormal_difference"].get():
+                    messages.append(
+                        Message(
+                            column_name=col,
+                            message_type=MessageType.LARGEST_ABNORMAL,
+                            values=description,
+                        )
+                    )
+            elif ((description["max"] - description["95%"]) / description["max"]) > config["abnormal_threshold_difference"].get():
+                messages.append(
+                    Message(
+                        column_name=col,
+                        message_type=MessageType.LARGEST_ABNORMAL,
+                        values=description,
+                    )
                 )
-            )
-        # abnormally largest values
-        if ((description["max"] - description["95%"]) / (description["95%"] - description["90%"])) > config["largest_abnormal_difference"].get():
-            messages.append(
-                Message(
-                    column_name=col,
-                    message_type=MessageType.LARGEST_ABNORMAL,
-                    values=description,
-                )
-            )
 
     if description["type"] not in {
         Variable.S_TYPE_UNSUPPORTED,

--- a/pandas_profiling/model/messages.py
+++ b/pandas_profiling/model/messages.py
@@ -49,6 +49,11 @@ class MessageType(Enum):
     TYPE_DATE = 11
     """This variable is likely a datetime, but treated as categorical."""
 
+    SMALLEST_ABNORMAL = 12
+    """This variable has abnormally smallest values."""
+
+    LARGEST_ABNORMAL = 13
+    """This variable has abnormally largest values."""
 
 class Message(object):
     """A message object (type, values, column)."""
@@ -132,6 +137,24 @@ def check_variable_messages(col: str, description: dict) -> List[Message]:
             messages.append(
                 Message(
                     column_name=col, message_type=MessageType.ZEROS, values=description
+                )
+            )
+        # abnormally smallest values
+        if ((description["5%"] - description["min"]) / (description["10%"] - description["5%"])) > config["smallest_abnormal_difference"].get():
+            messages.append(
+                Message(
+                    column_name=col,
+                    message_type=MessageType.SMALLEST_ABNORMAL,
+                    values=description,
+                )
+            )
+        # abnormally largest values
+        if ((description["max"] - description["95%"]) / (description["95%"] - description["90%"])) > config["largest_abnormal_difference"].get():
+            messages.append(
+                Message(
+                    column_name=col,
+                    message_type=MessageType.LARGEST_ABNORMAL,
+                    values=description,
                 )
             )
 

--- a/pandas_profiling/view/report.py
+++ b/pandas_profiling/view/report.py
@@ -259,6 +259,10 @@ def render_variables_section(stats_object: dict) -> str:
                     formatted_values["row_classes"]["zeros"] = "alert"
                 elif m.message_type == MessageType.MISSING:
                     formatted_values["row_classes"]["missing"] = "alert"
+                elif m.message_type == MessageType.SMALLEST_ABNORMAL:
+                    formatted_values["row_classes"]["smallest"] = "alert"
+                elif m.message_type == MessageType.LARGEST_ABNORMAL:
+                    formatted_values["row_classes"]["largest"] = "alert"
 
         if row["type"] in {Variable.TYPE_NUM, Variable.TYPE_DATE}:
             formatted_values["histogram"] = histogram(

--- a/pandas_profiling/view/templates/messages.html
+++ b/pandas_profiling/view/templates/messages.html
@@ -83,14 +83,14 @@
                 </td>
             {% elif message.message_type == MessageType.SMALLEST_ABNORMAL %}
                 <td>
-                    <a class="anchor" href="#pp_var_{{ message.column_name }}"><code>{{ message.column_name }}</code></a> has abnormal smallest values: minimum = {{ message.values['min'] }}, P5 = {{ message.values['5%'] }}, P10 = {{ message.values['10%'] }}
+                    <a class="anchor" href="#pp_var_{{ message.column_name }}"><code>{{ message.column_name }}</code></a> has maybe abnormal smallest values: minimum = {{ message.values['min'] }}, P5 = {{ message.values['5%'] }}, P10 = {{ message.values['10%'] }}
                 </td>
                 <td>
                     <span class="label label-danger">Abnormal</span>
                 </td>
             {% elif message.message_type == MessageType.LARGEST_ABNORMAL %}
                 <td>
-                    <a class="anchor" href="#pp_var_{{ message.column_name }}"><code>{{ message.column_name }}</code></a> has abnormal largest values: maximum = {{ message.values['max'] }}, P95 = {{ message.values['95%'] }}, P90 = {{ message.values['90%'] }}
+                    <a class="anchor" href="#pp_var_{{ message.column_name }}"><code>{{ message.column_name }}</code></a> has maybe abnormal largest values: maximum = {{ message.values['max'] }}, P95 = {{ message.values['95%'] }}, P90 = {{ message.values['90%'] }}
                 </td>
                 <td>
                     <span class="label label-danger">Abnormal</span>

--- a/pandas_profiling/view/templates/messages.html
+++ b/pandas_profiling/view/templates/messages.html
@@ -81,6 +81,20 @@
                 <td>
                     <span class="label label-info">Type</span>
                 </td>
+            {% elif message.message_type == MessageType.SMALLEST_ABNORMAL %}
+                <td>
+                    <a class="anchor" href="#pp_var_{{ message.column_name }}"><code>{{ message.column_name }}</code></a> has abnormal smallest values: minimum = {{ message.values['min'] }}, P5 = {{ message.values['5%'] }}, P10 = {{ message.values['10%'] }}
+                </td>
+                <td>
+                    <span class="label label-danger">Abnormal</span>
+                </td>
+            {% elif message.message_type == MessageType.LARGEST_ABNORMAL %}
+                <td>
+                    <a class="anchor" href="#pp_var_{{ message.column_name }}"><code>{{ message.column_name }}</code></a> has abnormal largest values: maximum = {{ message.values['max'] }}, P95 = {{ message.values['95%'] }}, P90 = {{ message.values['90%'] }}
+                </td>
+                <td>
+                    <span class="label label-danger">Abnormal</span>
+                </td>
             {% else %}
                 <td colspan="2">Unknown type {{ message['mtype'] }} </td>
             {% endif %}

--- a/pandas_profiling/view/templates/variables/row_num_statistics.html
+++ b/pandas_profiling/view/templates/variables/row_num_statistics.html
@@ -10,6 +10,10 @@
             <td>{{ values['5%'] | fmt_numeric }}</td>
         </tr>
         <tr>
+            <th>10-th percentile</th>
+            <td>{{ values['10%'] | fmt_numeric }}</td>
+        </tr>
+        <tr>
             <th>Q1</th>
             <td>{{ values['25%'] | fmt_numeric }}</td>
         </tr>
@@ -20,6 +24,10 @@
         <tr>
             <th>Q3</th>
             <td>{{ values['75%'] | fmt_numeric }}</td>
+        </tr>
+         <tr>
+            <th>90-th percentile</th>
+            <td>{{ values['90%'] | fmt_numeric }}</td>
         </tr>
         <tr>
             <th>95-th percentile</th>


### PR DESCRIPTION
Abnormal values analysis: "Division by zero" is fixed
The error "Division by zero" is fixed.
For the variant of matches of values P90% and P95% the check for increase (in percentage) of a maximum from P95%.
For the variant of matches of values P5% and P10% the check for increase (in percentage) of P5% from a minimum.
Added flag "check_abnormal_values" to initiate abnormal values analysis (can be "False" by default).