### PR TITLE
Rejected Columns based on co-relation type

### DIFF
--- a/pandas_profiling/__init__.py
+++ b/pandas_profiling/__init__.py
@@ -93,7 +93,7 @@ class ProfileReport(object):
         """
         return self.description_set
 
-        def get_rejected_variables(self, threshold: float = 0.9, correlation_type: str = 'pearson') -> list:
+    def get_rejected_variables(self, threshold: float = 0.9, correlation_type: str = 'pearson') -> list:
         """Return a list of variable names being rejected for high 
         correlation with one of remaining variables.
         

--- a/pandas_profiling/__init__.py
+++ b/pandas_profiling/__init__.py
@@ -93,23 +93,30 @@ class ProfileReport(object):
         """
         return self.description_set
 
-    def get_rejected_variables(self, threshold: float = 0.9) -> list:
+        def get_rejected_variables(self, threshold: float = 0.9, correlation_type: str = 'pearson') -> list:
         """Return a list of variable names being rejected for high 
         correlation with one of remaining variables.
         
         Args:
             threshold: correlation value which is above the threshold are rejected (Default value = 0.9)
+            correlation_type: Type of Correlations available 'pearson', 'spearman', 'kendall', 'phi_k'
+            (Default value = pearson)
 
         Returns:
             A list of rejected variables.
         """
-        variable_profile = self.description_set["variables"]
-        result = []
-        for col, values in variable_profile.items():
-            if "correlation" in values:
-                if values["correlation"] > threshold:
-                    result.append(col)
-        return result
+        # variable_profile = self.description_set["variables"]
+        # result = []
+        # for col, values in variable_profile.items():
+        #     if "correlations" in values:
+        #         if values["correlations"] > threshold:
+        #             result.append(col)
+        # return result
+        correlations = self.description_set['correlations']
+        correlation = correlations[correlation_type]
+        correlation_tri = correlation.where(np.triu(np.ones(correlation.shape),k=1).astype(np.bool))
+        drop_cols = [i for i in correlation_tri if any(correlation_tri[i]>threshold)]
+        return drop_cols
 
     def to_file(self, output_file: Path or str, silent: bool = True) -> None:
         """Write the report to a file.

--- a/pandas_profiling/__init__.py
+++ b/pandas_profiling/__init__.py
@@ -105,13 +105,6 @@ class ProfileReport(object):
         Returns:
             A list of rejected variables.
         """
-        # variable_profile = self.description_set["variables"]
-        # result = []
-        # for col, values in variable_profile.items():
-        #     if "correlations" in values:
-        #         if values["correlations"] > threshold:
-        #             result.append(col)
-        # return result
         correlations = self.description_set['correlations']
         correlation = correlations[correlation_type]
         correlation_tri = correlation.where(np.triu(np.ones(correlation.shape),k=1).astype(np.bool))

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest=3.2.5
+pytest==3.2.5
 codecov
 pytest-cov
 nbval

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest
+pytest=3.2.5
 codecov
 pytest-cov
 nbval

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ requests
 missingno>=0.4.2
 matplotlib
 jinja2
-numpy
+numpy>=1.6.0
 pandas
 htmlmin
 phik


### PR DESCRIPTION
This PR is raised against to the Feature Request raised: https://github.com/pandas-profiling/pandas-profiling/issues/298

Helps in selecting type of Co-relation to be used in rejected Columns.

'pearson', 'spearman', 'kendall', 'phi_k'