### PR TITLE
Require numpy minimum version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ requests
 missingno>=0.4.2
 matplotlib
 jinja2
-numpy
+numpy>=1.16.0
 pandas
 htmlmin
 phik


### PR DESCRIPTION
https://travis-ci.com/pandas-profiling/pandas-profiling/jobs/270608894
```astropy 4.0 has requirement numpy>=1.16, but you'll have numpy 1.15.4 which is incompatible.```