### PR TITLE
Handling for constant (values, length) variables

### DIFF
--- a/src/pandas_profiling/model/messages.py
+++ b/src/pandas_profiling/model/messages.py
@@ -52,6 +52,10 @@ class MessageType(Enum):
     """This variable is likely a datetime, but treated as categorical."""
 
     UNIQUE = 12
+    """This variable has unique values."""
+
+    CONSTANT_LENGTH = 13
+    """This variable has a constant length"""
 
 
 class Message(object):
@@ -161,7 +165,7 @@ def check_variable_messages(col: str, description: dict) -> List[Message]:
         )
 
     # Categorical
-    if description["type"] in {Variable.TYPE_CAT}:
+    if description["type"] == Variable.TYPE_CAT:
         if description["date_warning"]:
             messages.append(
                 Message(column_name=col, message_type=MessageType.TYPE_DATE, values={})
@@ -177,6 +181,21 @@ def check_variable_messages(col: str, description: dict) -> List[Message]:
                     message_type=MessageType.HIGH_CARDINALITY,
                     values=description,
                     fields={"n_unique"},
+                )
+            )
+
+        # Constant length
+        if (
+            "composition" in description
+            and description["composition"]["min_length"]
+            == description["composition"]["max_length"]
+        ):
+            messages.append(
+                Message(
+                    column_name=col,
+                    message_type=MessageType.CONSTANT_LENGTH,
+                    values=description,
+                    fields={"composition_min_length", "composition_max_length"},
                 )
             )
 

--- a/src/pandas_profiling/model/messages.py
+++ b/src/pandas_profiling/model/messages.py
@@ -187,8 +187,7 @@ def check_variable_messages(col: str, description: dict) -> List[Message]:
         # Constant length
         if (
             "composition" in description
-            and description["composition"]["min_length"]
-            == description["composition"]["max_length"]
+            and description["min_length"] == description["max_length"]
         ):
             messages.append(
                 Message(

--- a/src/pandas_profiling/report/structure/report.py
+++ b/src/pandas_profiling/report/structure/report.py
@@ -14,6 +14,7 @@ from pandas_profiling.model.base import (
     ImagePath,
     Generic,
 )
+from pandas_profiling.model.messages import MessageType
 from pandas_profiling.report.structure.variables import (
     render_boolean,
     render_categorical,
@@ -144,13 +145,16 @@ def render_variables_section(dataframe_summary: dict) -> list:
         # Per type template variables
         template_variables.update(type_to_func[summary["type"]](template_variables))
 
+        # Ignore these
+        ignore = summary["type"] == Generic or MessageType.CONST.value in warnings
+
         templs.append(
             Preview(
                 template_variables["top"],
                 template_variables["bottom"],
                 anchor_id=template_variables["varid"],
                 name=idx,
-                ignore="ignore" in template_variables,
+                ignore=ignore,
             )
         )
 

--- a/src/pandas_profiling/report/structure/variables/render_generic.py
+++ b/src/pandas_profiling/report/structure/variables/render_generic.py
@@ -37,7 +37,6 @@ def render_generic(summary):
     return {
         "top": Sequence([info, table, HTML("")], sequence_type="grid"),
         "bottom": None,
-        "ignore": "ignore",
     }
 
     # Add class Ignore


### PR DESCRIPTION
- Constant length warning / message: Inform the user for categorials with constant length
- Variables with constant values are "ignored" (strikethrough and grey)