### PR TITLE
Update describe.py to fix n_infinite

### DIFF
--- a/src/pandas_profiling/model/describe.py
+++ b/src/pandas_profiling/model/describe.py
@@ -274,7 +274,7 @@ def describe_supported(series: pd.Series, series_description: dict) -> dict:
     # number of non-NaN observations in the Series
     count = series.count()
     # number of infinite observations in the Series
-    n_infinite = count - series.count()
+    n_infinite = leng - count
 
     distinct_count = series_description["distinct_count_without_nan"]
 


### PR DESCRIPTION
Hey guys I was reading through the code and came across this:
```
count = series.count()
n_inifinte = count - series.count()
```

So I am pretty sure n_infinite is always 0. I believe the following expression is correct:

```
leng = len(series)
count = series.count()
n_inifinite = leng - count
```

Hope this helps