### PR TITLE
ui: columns of duplicate rows

### DIFF
--- a/src/pandas_profiling/report/presentation/flavours/html/templates/wrapper/assets/style.css
+++ b/src/pandas_profiling/report/presentation/flavours/html/templates/wrapper/assets/style.css
@@ -270,7 +270,7 @@ a.anchor-pos-variable{
     /*top: -70px;*/
 }
 
-#sample-container{
+#sample-container, #duplicate-container{
     overflow: auto;
     width: 100%;
     overflow-y: hidden;


### PR DESCRIPTION
Fix the UI issue that the columns of duplicate rows go outside container when there are many features.

Current columns are escaping the boundry:
<img width="1017" alt="Screen Shot 2020-05-04 at 6 45 16 PM" src="https://user-images.githubusercontent.com/22522811/81031164-3a933b00-8e40-11ea-8ce4-366d12ef0b1c.png">


After fix:
<img width="1021" alt="Screen Shot 2020-05-04 at 7 31 14 PM" src="https://user-images.githubusercontent.com/22522811/81031169-4121b280-8e40-11ea-9c8b-5398bf07bb03.png">
