### PR TITLE
Correct ProfileReport config_file parameter documentation

### DIFF
--- a/docsrc/source/pages/advanced_usage.rst
+++ b/docsrc/source/pages/advanced_usage.rst
@@ -136,7 +136,7 @@ Then, change the configuration to your liking.
 
   from pandas_profiling import ProfileReport
 
-  profile = ProfileReport(df, configuration_file="your_config.yml")
+  profile = ProfileReport(df, config_file="your_config.yml")
   profile.to_file("report.html")
 
 Sample configuration files


### PR DESCRIPTION
The documentation has `configuration_file` listed as the parameter for `ProfileReport`, but the code actually uses `config_file`. This change updates the documentation to reflect the code.