### PR TITLE
fix ValueError race condition when running multiprocessing with describe1d

### DIFF
--- a/src/pandas_profiling/model/summary.py
+++ b/src/pandas_profiling/model/summary.py
@@ -427,7 +427,7 @@ def describe_1d(series: pd.Series) -> dict:
         return stats
 
     # Make sure pd.NA is not in the series
-    series.fillna(np.nan, inplace=True)
+    series = series.fillna(np.nan)
 
     # Infer variable types
     # TODO: use visions for type inference


### PR DESCRIPTION
References issue #537 

Problem :
ValueError is raised when running ProfileReport on large datasets and with multiprocessing on (pool_size >1). This is likely due to the `series.fillna(np.nan, inplace=True)`  in summary.py seems to be performing multiple in-place mutations to the underlying DataFrame object through the passed series reference, resulting in some kind of race condition where two of the processes try to write to the DataFrame at the same time and the ValueError then occurs. This is also why changing the pool_size to 1 fixes the issue, and why the error doesn't always occur - you probably need enough data and threads to hit the race condition. 

Solution : 
Replace `series.fillna(np.nan, inplace=True)` with `series = series.fillna(np.nan)` , negating any side effects from mutation. 

