### PR TITLE
Update get_scatter_matrix for sparse dataframes

### DIFF
--- a/src/pandas_profiling/model/summary.py
+++ b/src/pandas_profiling/model/summary.py
@@ -689,13 +689,12 @@ def get_scatter_matrix(df, variables):
 
         scatter_matrix = {x: {y: "" for y in continuous_variables} for x in targets}
 
-        # check if any na still exists, and remove it before computing scatter matrix
-        df = df.dropna(subset=continuous_variables)
-
         for x in targets:
             for y in continuous_variables:
                 if x in continuous_variables:
-                    scatter_matrix[x][y] = scatter_pairwise(df[x], df[y], x, y)
+                    # check if any na still exists, and remove it before computing scatter matrix
+                    df_temp = df[[x,y]].dropna()
+                    scatter_matrix[x][y] = scatter_pairwise(df_temp[x], df_temp[y], x, y)
     else:
         scatter_matrix = {}
 

--- a/src/pandas_profiling/visualisation/plot.py
+++ b/src/pandas_profiling/visualisation/plot.py
@@ -269,13 +269,11 @@ def scatter_pairwise(series1, series2, x_label, y_label) -> str:
     color = config["html"]["style"]["primary_color"].get(str)
     scatter_threshold = config["plot"]["scatter_threshold"].get(int)
 
-    indices = (series1.notna()) & (series2.notna())
-
     if len(series1) > scatter_threshold:
         cmap = sns.light_palette(color, as_cmap=True)
-        plt.hexbin(series1[indices], series2[indices], gridsize=15, cmap=cmap)
+        plt.hexbin(series1, series2, gridsize=15, cmap=cmap)
     else:
-        plt.scatter(series1[indices], series2[indices], color=color)
+        plt.scatter(series1, series2, color=color)
     return plot_360_n0sc0pe(plt)
 
 


### PR DESCRIPTION
For a dataframe like:

	A	B	C
0	1.0	7.0	NaN
1	2.0	8.0	NaN
2	3.0	9.0	NaN
3	4.0	NaN	13.0
4	5.0	NaN	14.0
5	6.0	NaN	15.0
6	NaN	10.0	16.0
7	NaN	11.0	17.0
8	NaN	12.0	18.0

the 'Interactions' tab would not display any data (as all rows contain NaN's) while any pair of columns would contain valid data to plot.
This change allows columns A, B, and C to be pairwise plotted against each other by only removing rows with NaN's between the pairwise columns.