### PR TITLE
profile_report: use to_json() to encode pd.DataFrame to json

### DIFF
--- a/src/pandas_profiling/profile_report.py
+++ b/src/pandas_profiling/profile_report.py
@@ -332,6 +332,9 @@ class ProfileReport(SerializeReport, object):
                 if isinstance(o, pd.Series):
                     return self.default(o.to_dict())
 
+                if isinstance(o, pd.DataFrame):
+                    return o.to_json()
+
                 if isinstance(o, np.integer):
                     return o.tolist()
 


### PR DESCRIPTION
ProfileReport.to_json() exports some data using Pandas DataFrame and
without this fix they are encoded using str(), which doesn't give the
whole data.