### PR TITLE
Bump pre-commit versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,12 @@
 repos:
 -   repo: https://github.com/python/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black
       language_version: python3.7
 -   repo: https://github.com/nbQA-dev/nbQA
-    rev: 0.3.3
+    rev: 0.4.0
     hooks:
     - id: nbqa-black
+      additional_dependencies: [black==20.8b1]
       args: [--nbqa-mutate]


### PR DESCRIPTION
Hi :wave:

using `rev: stable` will raise a warning in pre-commit (see https://github.com/pre-commit/pre-commit/issues/974) so here's a PR to pin it to a tag (as well as to pin the version for nbqa)