### PR TITLE
BUG: Make sure nans are converted to empty strings (closes #613)

### DIFF
--- a/src/pandas_profiling/model/summary.py
+++ b/src/pandas_profiling/model/summary.py
@@ -286,7 +286,8 @@ def describe_1d(series: pd.Series) -> dict:
             A dict containing calculated series description values.
         """
         # Make sure we deal with strings (Issue #100)
-        series = series.astype(str)
+        # Make sure nans are converted to empty strings (Issue #613)
+        series = series.fillna('').astype('str')
 
         # Only run if at least 1 non-missing value
         value_counts = series_description["value_counts_without_nan"]

--- a/tests/issues/test_issue613.py
+++ b/tests/issues/test_issue613.py
@@ -1,0 +1,17 @@
+"""
+Test for issue 613:
+https://github.com/pandas-profiling/pandas-profiling/issues/613
+"""
+import numpy as np
+import pandas as pd
+
+from pandas_profiling import ProfileReport
+
+def test_issue100():
+
+    df = pd.DataFrame([{'col': 'ABCD'}, {'col': 'DEFG'}, {'col': np.nan}])
+
+    report = ProfileReport(df)
+    
+    assert report.description_set['variables']['col']['min_length'] = 0
+    


### PR DESCRIPTION
NaN values are being converted to string "nan"

I fixed this issue by making sure Nans were replaced by empty strings first