### PR TITLE
Handle on the fly decompression of data files supported by pandas (#652)

### DIFF
--- a/src/pandas_profiling/utils/dataframe.py
+++ b/src/pandas_profiling/utils/dataframe.py
@@ -50,7 +50,7 @@ def remove_suffix(text: str, suffix: str) -> str:
     Notes:
         In python 3.9+, there is a built-in string method called removesuffix() that can serve this purpose.
     """
-    return text[:-len(suffix)] if suffix and text.endswith(suffix) else text
+    return text[: -len(suffix)] if suffix and text.endswith(suffix) else text
 
 
 def uncompressed_extension(file_name: Path) -> str:

--- a/src/pandas_profiling/utils/dataframe.py
+++ b/src/pandas_profiling/utils/dataframe.py
@@ -21,6 +21,55 @@ https://github.com/pandas-profiling/pandas-profiling/issues"""
     )
 
 
+def is_supported_compression(file_extension: str) -> bool:
+    """Determine if the given file extension indicates a compression format that pandas can handle automatically.
+
+    Args:
+        file_extension (str): the file extension to test
+
+    Returns:
+        bool: True if the extension indicates a compression format that pandas handles automatically and False otherwise
+
+    Notes:
+        Pandas can handle on the fly decompression from the following extensions: ‘.bz2’, ‘.gz’, ‘.zip’, or ‘.xz’
+        (otherwise no decompression). If using ‘.zip’, the ZIP file must contain exactly one data file to be read in.
+    """
+    return file_extension.lower() in [".bz2", ".gz", ".xz", ".zip"]
+
+
+def remove_suffix(text: str, suffix: str) -> str:
+    """Removes the given suffix from the given string.
+
+    Args:
+        text (str): the string to remove the suffix from
+        suffix (str): the suffix to remove from the string
+
+    Returns:
+        str: the string with the suffix removed, if the string ends with the suffix, otherwise the unmodified string
+
+    Notes:
+        In python 3.9+, there is a built-in string method called removesuffix() that can serve this purpose.
+    """
+    return text[:-len(suffix)] if suffix and text.endswith(suffix) else text
+
+
+def uncompressed_extension(file_name: Path) -> str:
+    """Returns the uncompressed extension of the given file name.
+
+    Args:
+        file_name (Path): the file name to get the uncompressed extension of
+
+    Returns:
+        str: the uncompressed extension, or the original extension if pandas doesn't handle it automatically
+    """
+    extension = file_name.suffix.lower()
+    return (
+        Path(remove_suffix(str(file_name).lower(), extension)).suffix
+        if is_supported_compression(extension)
+        else extension
+    )
+
+
 def read_pandas(file_name: Path) -> pd.DataFrame:
     """Read DataFrame based on the file extension. This function is used when the file is in a standard format.
     Various file types are supported (.csv, .json, .jsonl, .data, .tsv, .xls, .xlsx, .xpt, .sas7bdat, .parquet)
@@ -40,7 +89,7 @@ def read_pandas(file_name: Path) -> pd.DataFrame:
         user input, which is currently used in the editor integration. For more advanced use cases, the user should load
         the DataFrame in code.
     """
-    extension = file_name.suffix.lower()
+    extension = uncompressed_extension(file_name)
     if extension == ".json":
         df = pd.read_json(str(file_name))
     elif extension == ".jsonl":


### PR DESCRIPTION
Pandas can handle on the fly decompression from the following extensions: ‘.bz2’, ‘.gz’, ‘.zip’, or ‘.xz’ (otherwise no decompression). Now the profiler can as well. (#652)

Using LZMA (.xz) typically yields a compression ratio of 25:1 for my very large .csv datasets (many GBs).  Being able to operate on them compressed with on the fly support in pandas has been extremely beneficial.  This patch extends these same benefits to the profiler.  I think others will benefit as well.
