### PR TITLE
Detect dtype from pandas df

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,6 @@ df = pd.DataFrame(
 To generate the report, run:
 ```python
 profile = ProfileReport(df, title="Pandas Profiling Report")
-
-# when dtypes are changed by `astype` function. Detect (new)dtypes from dataframe itself
-profile2 = ProfileReport(df, title="Pandas Profiling Report", infer_dtypes=False)
 ```
 
 ### Explore deeper
@@ -251,14 +248,31 @@ A set of options is available in order to adapt the report generated.
 More settings can be found in the [default configuration file](https://github.com/pandas-profiling/pandas-profiling/blob/master/src/pandas_profiling/config_default.yaml), [minimal configuration file](https://github.com/pandas-profiling/pandas-profiling/blob/master/src/pandas_profiling/config_minimal.yaml) and [dark themed configuration file](https://github.com/pandas-profiling/pandas-profiling/blob/master/src/pandas_profiling/config_dark.yaml).
 
 **Example**
-
+- configure your report. You can refer advanced usage docs [here](https://pandas-profiling.github.io/pandas-profiling/docs/master/rtd/pages/advanced_usage.html)
 ```python
 profile = df.profile_report(title='Pandas Profiling Report', plot={'histogram': {'bins': 8}})
 profile.to_file("output.html")
+```
 
-# If dtypes are changed (using `astype`) and need to consider new dtypes, set `infer_dtypes`: False
-profile2 = df.profile_report(title='Alternative Report', infer_dtypes=False)
-profie2.to_file('output2.html')
+- If dtypes are changed (using `astype`) and need to consider the new dtypes, set `infer_dtypes`: False
+```python3
+df = pd.DataFrame({
+    'Dummy': ['X', 'Y', 'X', 'X', 'Y', 'Y', 'Y', 'X'],
+    'EmpID': [9940243658, 9940243537, 9940243103, 9940242844, 9940242844, 9940242840, 9940242774, 9940242774]
+})
+
+df['EmpID'] = df['EmpID'].astype('str')
+
+# `EmpID` would be considered as `real number` in below report eventhough it is casted as `str` above.
+# This is because by default pandas-profiling tries to infer the dtype.
+profile2 = df.profile_report(title='Inferred dtype - Report')
+profile2.to_file('output2.html')
+
+
+# To read `EmpID` as a category item / use the same dtypes as read by pandas (df.dtypes)
+profile3 = df.profile_report(title='Detected dtype - Report', infer_dtypes=False)
+profile3.to_file('output3.html')
+
 ```
 
 ## Supporting open source

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ df = pd.DataFrame(
 To generate the report, run:
 ```python
 profile = ProfileReport(df, title="Pandas Profiling Report")
+
+# when dtypes are changed by `astype` function. Detect (new)dtypes from dataframe itself
+profile2 = ProfileReport(df, title="Pandas Profiling Report", infer_dtypes=False)
 ```
 
 ### Explore deeper
@@ -241,6 +244,9 @@ A set of options is available in order to adapt the report generated.
 * `title` (`str`): Title for the report ('Pandas Profiling Report' by default).
 * `pool_size` (`int`): Number of workers in thread pool. When set to zero, it is set to the number of CPUs available (0 by default).
 * `progress_bar` (`bool`): If True, `pandas-profiling` will display a progress bar.
+* `infer_dtypes` (`bool`): 
+  * `True` by default. When `True` the `dtype` of variables are inferred by `pandas-profiling`.
+  * When `False`, the data-types of variables are detected from `pandas`. dataframe. (A variable `dtype` can be changed using `astype` function and the same `dtype` is used by `pandas-profiling`).
 
 More settings can be found in the [default configuration file](https://github.com/pandas-profiling/pandas-profiling/blob/master/src/pandas_profiling/config_default.yaml), [minimal configuration file](https://github.com/pandas-profiling/pandas-profiling/blob/master/src/pandas_profiling/config_minimal.yaml) and [dark themed configuration file](https://github.com/pandas-profiling/pandas-profiling/blob/master/src/pandas_profiling/config_dark.yaml).
 
@@ -249,6 +255,10 @@ More settings can be found in the [default configuration file](https://github.co
 ```python
 profile = df.profile_report(title='Pandas Profiling Report', plot={'histogram': {'bins': 8}})
 profile.to_file("output.html")
+
+# If dtypes are changed (using `astype`) and need to consider new dtypes, set `infer_dtypes`: False
+profile2 = df.profile_report(title='Alternative Report', infer_dtypes=False)
+profie2.to_file('output2.html')
 ```
 
 ## Supporting open source

--- a/src/pandas_profiling/config_default.yaml
+++ b/src/pandas_profiling/config_default.yaml
@@ -13,6 +13,9 @@ dataset:
 variables:
   descriptions: {}
 
+# infer dtypes
+infer_dtypes: True
+
 # Show the description at each variable (in addition to the overview tab)
 show_variable_description: True
 

--- a/src/pandas_profiling/config_minimal.yaml
+++ b/src/pandas_profiling/config_minimal.yaml
@@ -13,6 +13,9 @@ dataset:
 variables:
   descriptions: {}
 
+# infer dtypes
+infer_dtypes: True
+
 # Show the description at each variable (in addition to the overview tab)
 show_variable_description: True
 

--- a/src/pandas_profiling/controller/console.py
+++ b/src/pandas_profiling/controller/console.py
@@ -61,6 +61,20 @@ def parse_args(args: Union[list, None] = None) -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--infer_dtypes",
+        default=False,
+        action="store_true",
+        help="To infer dtypes of the dataframe",
+    )
+
+    parser.add_argument(
+        "--no-infer_dtypes",
+        dest="infer_dtypes",
+        action="store_false",
+        help="To read dtypes as read by pandas"
+    )
+
+    parser.add_argument(
         "--config_file",
         type=str,
         default=None,

--- a/src/pandas_profiling/model/summary.py
+++ b/src/pandas_profiling/model/summary.py
@@ -27,7 +27,9 @@ from pandas_profiling.visualisation.plot import scatter_pairwise
 
 
 def describe_1d(series: pd.Series, summarizer: BaseSummarizer, typeset) -> dict:
-    """Describe a series (infer the variable type, then calculate type-specific values).
+    """Describe a series based on infer_dtypes param in config which is set True by default
+    when infer_dtypes is True, infer the variable type then calculate type-specific values
+    when infer_dtypes is False, detect type as read by pandas.
 
     Args:
         series: The Series to describe.
@@ -39,9 +41,14 @@ def describe_1d(series: pd.Series, summarizer: BaseSummarizer, typeset) -> dict:
     # Make sure pd.NA is not in the series
     series = series.fillna(np.nan)
 
-    # Infer variable types
-    vtype = typeset.infer_type(series)
-    series = typeset.cast_to_inferred(series)
+    infer_dtypes = config["infer_dtypes"].get(bool)
+    if infer_dtypes:
+        # Infer variable types
+        vtype = typeset.infer_type(series)
+        series = typeset.cast_to_inferred(series)
+    else:
+        # Detect variable types as read by pandas
+        vtype = typeset.detect_type(series)
 
     return summarizer.summarize(series, dtype=vtype)
 

--- a/src/pandas_profiling/model/summary.py
+++ b/src/pandas_profiling/model/summary.py
@@ -41,13 +41,14 @@ def describe_1d(series: pd.Series, summarizer: BaseSummarizer, typeset) -> dict:
     # Make sure pd.NA is not in the series
     series = series.fillna(np.nan)
 
+    # get `infer_dtypes` (bool) from config
     infer_dtypes = config["infer_dtypes"].get(bool)
     if infer_dtypes:
         # Infer variable types
         vtype = typeset.infer_type(series)
         series = typeset.cast_to_inferred(series)
     else:
-        # Detect variable types as read by pandas
+        # Detect variable types from pandas dataframe (df.dtypes). [new dtypes, changed using `astype` function are now considered]
         vtype = typeset.detect_type(series)
 
     return summarizer.summarize(series, dtype=vtype)

--- a/src/pandas_profiling/profile_report.py
+++ b/src/pandas_profiling/profile_report.py
@@ -91,7 +91,6 @@ class ProfileReport(SerializeReport):
         self._json = None
         self._typeset = None
         self._summarizer = None
-        self._infer_dtypes = None
 
         if df is not None:
             # preprocess df
@@ -148,7 +147,6 @@ class ProfileReport(SerializeReport):
             self._html = None
             self._widgets = None
             self._json = None
-            self._infer_dtypes = None
 
         if len(vars) == 1:
             config[list(vars.keys())[0]] = list(vars.values())[0]
@@ -174,12 +172,6 @@ class ProfileReport(SerializeReport):
                 self.title, self.df, self.summarizer, self.typeset, self._sample
             )
         return self._description_set
-
-    @property
-    def infer_dtypes(self):
-        if self._infer_dtypes is None:
-            self._infer_dtypes = config["infer_dtypes"].get(bool)
-        return self._infer_dtypes
 
     @property
     def title(self):

--- a/src/pandas_profiling/profile_report.py
+++ b/src/pandas_profiling/profile_report.py
@@ -50,6 +50,7 @@ class ProfileReport(SerializeReport):
             sample: optional dict(name="Sample title", caption="Caption", data=pd.DataFrame())
             **kwargs: other arguments, for valid arguments, check the default configuration file.
         """
+        config.clear() # to reset (previous) config.
         if config_file is not None and minimal:
             raise ValueError(
                 "Arguments `config_file` and `minimal` are mutually exclusive."
@@ -90,6 +91,7 @@ class ProfileReport(SerializeReport):
         self._json = None
         self._typeset = None
         self._summarizer = None
+        self._infer_dtypes = None
 
         if df is not None:
             # preprocess df
@@ -146,6 +148,7 @@ class ProfileReport(SerializeReport):
             self._html = None
             self._widgets = None
             self._json = None
+            self._infer_dtypes = None
 
         if len(vars) == 1:
             config[list(vars.keys())[0]] = list(vars.values())[0]
@@ -171,6 +174,12 @@ class ProfileReport(SerializeReport):
                 self.title, self.df, self.summarizer, self.typeset, self._sample
             )
         return self._description_set
+
+    @property
+    def infer_dtypes(self):
+        if self._infer_dtypes is None:
+            self._infer_dtypes = config["infer_dtypes"].get(bool)
+        return self._infer_dtypes
 
     @property
     def title(self):


### PR DESCRIPTION
This pull request is to address issue https://github.com/pandas-profiling/pandas-profiling/issues/676 <br>

## Issue
- Developer may choose to change the type of the variable(s) after reading from `pandas`.
- So, the variable type can be changed with the help of `astype` function.
- However, `Pandas-Profiling` is ignores the re-imagined data-type and chooses to infer on its own.
- This is due to the code located here. ( Pointed by @ieaves: https://github.com/pandas-profiling/pandas-profiling/issues/676#issuecomment-767988012 )
https://github.com/pandas-profiling/pandas-profiling/blob/d4e70185fa7e16b1d0b07dfb731897ef06bb3067/src/pandas_profiling/model/summary.py#L43

## Solution
- Suggested by @ieaves here: https://github.com/pandas-profiling/pandas-profiling/issues/676#issuecomment-769209611
- The goal is to not break existing code base & make as minimal required changes as possible.
- Add a new configuration parameter called `infer_dtypes` of `bool` type, which is set `True` by default.
(So as to ensure no code base is effected by this new param)
- `infer_dtypes` is now an optional keyword argument for `ProfileReport` class in ` src/pandas_profiling/profile_report.py` 
- Passing `infer_dtype` variable across many functions is a risky choice. So, it's suggested to use this param in the config file.
- In function `describe_1d` of `src/pandas_profiling/model/summary.py`
    - When `infer_dtypes` is `True` it would run the existing code, i.e infer the `dtype`.
    - When `infer_dtypes` is set `False`, it would not infer the `dtype` rather it detects the `dtype` from the `pandas` dataframe
```python3
    # Get `infer_dtypes` from config
    infer_dtypes = config["infer_dtypes"].get(bool)
    if infer_dtypes:
        # Infer variable types
        vtype = typeset.infer_type(series)
        series = typeset.cast_to_inferred(series)
    else:
        # Detect variable types from `pandas` dataframe
        vtype = typeset.detect_type(series)
```
- Hence `infer_dtypes` is added in `src/pandas_profiling/config_default.yaml` & `src/pandas_profiling/config_minimal.yaml` and is set `True` by default.
- To reflect the same in console version of `pandas_profiling`, two command line arguments are added to match the new bool param.
    - `--infer_dtypes`: equivalent to `infer_dtypes = True` and has no affect anyway since by default this param is set `True`
    - `--no-infer_dtypes`: equivalent to `infer_dtypes = False` and is require when you want `pandas_profiling` to get`dtype` from `pandas` dataframe

## Usage
```python
import numpy as np
import pandas as pd
from pandas_profiling import ProfileReport

df = pd.DataFrame({
    'Dummy': ['X', 'Y', 'X', 'X', 'Y', 'Y', 'Y', 'X'],
    'Contract': [9940243658, 9940243537, 9940243103, 9940242844, 9940242844, 9940242840, 9940242774, 9940242774]
})

# New Feature
# Generate report by using the `dtypes` from dataframe. Developer may choose to change the variable type and the changed dtypes are considered.
ProfileReport(df, infer_dtypes=False)
df.profile_report(infer_dtypes=False)

# Current usage 
# Little(No) effect. This generate report by infering dtypes irrespective of change in dtypes by the developer.
ProfileReport(df)
ProfileReport(df, infer_dtypes=True)
df.profile_report()
df.profile_report(infer_dtypes=True)
```

## Additional issue found:
```python3
import numpy as np
import pandas as pd
from pandas_profiling import ProfileReport

df = pd.DataFrame({
    'Dummy': ['X', 'Y', 'X', 'X', 'Y', 'Y', 'Y', 'X'],
    'Contract': [9940243658, 9940243537, 9940243103, 9940242844, 9940242844, 9940242840, 9940242774, 9940242774]
})

ProfileReport(df, title='MyAnalysis')    # ---> (1)
ProfileReport(df)                        # ---> (2)
```
- When (1) followed by (2) is executed, the `title` name set in (1) is also appearing in report generated by (2)
- It shouldn't be the case as (2) doesn't have any `title` param (expected title: default title "Pandas Profiling Report")

## Additional issue fix:
- It is assured that by clearing the `config` variable from the cache for every time `ProfileReport` / `profile_report` is called fixes the issue.
- So below line is added as the first line in the constructor of `ProfileReport`, so as to avoid any previous instance of `config` to be used again.
```python
config.clear() # to reset (previous) config.
```