### PR TITLE
Consolidated the to_expectation_suite methods

### DIFF
--- a/examples/features/great_expectations_example.py
+++ b/examples/features/great_expectations_example.py
@@ -1,8 +1,9 @@
+import great_expectations as ge
 import pandas as pd
 
 from pandas_profiling import ProfileReport
 from pandas_profiling.utils.cache import cache_file
-import great_expectations as ge
+
 file_name = cache_file(
     "titanic.csv",
     "https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv",
@@ -10,11 +11,7 @@ file_name = cache_file(
 
 df = pd.read_csv(file_name)
 
-profile = ProfileReport(
-    df,
-    title="Pandas Profiling Report",
-    explorative=True
-)
+profile = ProfileReport(df, title="Pandas Profiling Report", explorative=True)
 
 # Example 1
 # Obtain expectation suite, this includes profiling the dataset, saving the expectation suite, validating the
@@ -27,8 +24,7 @@ suite = profile.to_expectation_suite(suite_name="titanic_expectations")
 data_context = ge.data_context.DataContext(context_root_dir="my_ge_root_directory/")
 
 suite = profile.to_expectation_suite(
-    suite_name="titanic_expectations",
-    data_context=data_context
+    suite_name="titanic_expectations", data_context=data_context
 )
 
 # Example 3
@@ -37,7 +33,7 @@ suite = profile.to_expectation_suite(
     suite_name="titanic_expectations",
     save_suite=False,
     run_validation=False,
-    build_data_docs=False
+    build_data_docs=False,
 )
 
 # Example 4
@@ -53,31 +49,20 @@ suite = profile.to_expectation_suite(
     data_context=data_context,
     save_suite=False,
     run_validation=False,
-    build_data_docs=False
+    build_data_docs=False,
 )
 
 # Save the suite
 data_context.save_expectation_suite(suite)
 
 # Run validation on your dataframe
-batch = ge.dataset.PandasDataset(
-    df,
-    expectation_suite=suite
-)
+batch = ge.dataset.PandasDataset(df, expectation_suite=suite)
 
 results = data_context.run_validation_operator(
-    "action_list_operator",
-    assets_to_validate=[batch]
+    "action_list_operator", assets_to_validate=[batch]
 )
 validation_result_identifier = results.list_validation_result_identifiers()[0]
 
 # Build and open data docs
 data_context.build_data_docs()
 data_context.open_data_docs(validation_result_identifier)
-
-
-
-
-
-
-

--- a/examples/features/great_expectations_example.py
+++ b/examples/features/great_expectations_example.py
@@ -2,7 +2,7 @@ import pandas as pd
 
 from pandas_profiling import ProfileReport
 from pandas_profiling.utils.cache import cache_file
-
+import great_expectations as ge
 file_name = cache_file(
     "titanic.csv",
     "https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv",
@@ -10,10 +10,74 @@ file_name = cache_file(
 
 df = pd.read_csv(file_name)
 
-profile = ProfileReport(df, title="Pandas Profiling Report", explorative=True)
+profile = ProfileReport(
+    df,
+    title="Pandas Profiling Report",
+    explorative=True
+)
 
-# Obtain expectations suite, this includes profiling the dataset
-suite = profile.to_expectation_suite()
+# Example 1
+# Obtain expectation suite, this includes profiling the dataset, saving the expectation suite, validating the
+# dataframe, and building data docs
+suite = profile.to_expectation_suite(suite_name="titanic_expectations")
 
-# Or write directly as expectation suite json in GE
-profile.to_expectations_with_validation_operator(suite_name="titanic_expectations")
+# Example 2
+# Run Great Expectations while specifying the directory with an existing Great Expectations set-up by passing in a
+# Data Context
+data_context = ge.data_context.DataContext(context_root_dir="my_ge_root_directory/")
+
+suite = profile.to_expectation_suite(
+    suite_name="titanic_expectations",
+    data_context=data_context
+)
+
+# Example 3
+# Just build the suite
+suite = profile.to_expectation_suite(
+    suite_name="titanic_expectations",
+    save_suite=False,
+    run_validation=False,
+    build_data_docs=False
+)
+
+# Example 4
+# If you would like to use the method to just build the suite, and then manually save the suite, validate the dataframe,
+# and build data docs
+
+# First instantiate a data_context
+data_context = ge.data_context.DataContext(context_root_dir="my_ge_root_directory/")
+
+# Create the suite
+suite = profile.to_expectation_suite(
+    suite_name="titanic_expectations",
+    data_context=data_context,
+    save_suite=False,
+    run_validation=False,
+    build_data_docs=False
+)
+
+# Save the suite
+data_context.save_expectation_suite(suite)
+
+# Run validation on your dataframe
+batch = ge.dataset.PandasDataset(
+    df,
+    expectation_suite=suite
+)
+
+results = data_context.run_validation_operator(
+    "action_list_operator",
+    assets_to_validate=[batch]
+)
+validation_result_identifier = results.list_validation_result_identifiers()[0]
+
+# Build and open data docs
+data_context.build_data_docs()
+data_context.open_data_docs(validation_result_identifier)
+
+
+
+
+
+
+

--- a/src/pandas_profiling/expectations_report.py
+++ b/src/pandas_profiling/expectations_report.py
@@ -33,14 +33,15 @@ class ExpectationHandler(Handler):
 
 
 class ExpectationsReport:
-    def to_expectation_suite(self,
-                             suite_name=None,
-                             data_context=None,
-                             save_suite=True,
-                             run_validation=True,
-                             build_data_docs=True,
-                             handler=None,
-                             ):
+    def to_expectation_suite(
+        self,
+        suite_name=None,
+        data_context=None,
+        save_suite=True,
+        run_validation=True,
+        build_data_docs=True,
+        handler=None,
+    ):
         """
         All parameters default to True to make it easier to access the full functionality of Great Expectations out of
         the box.
@@ -75,7 +76,9 @@ class ExpectationsReport:
         if not data_context:
             data_context = ge.data_context.DataContext()
 
-        suite = data_context.create_expectation_suite(suite_name, overwrite_existing=True)
+        suite = data_context.create_expectation_suite(
+            suite_name, overwrite_existing=True
+        )
         if save_suite:
             data_context.save_expectation_suite(suite)
 
@@ -95,7 +98,9 @@ class ExpectationsReport:
             results = data_context.run_validation_operator(
                 "action_list_operator", assets_to_validate=[batch]
             )
-            validation_result_identifier = results.list_validation_result_identifiers()[0]
+            validation_result_identifier = results.list_validation_result_identifiers()[
+                0
+            ]
 
             # Write expectations and open data docs
 

--- a/src/pandas_profiling/expectations_report.py
+++ b/src/pandas_profiling/expectations_report.py
@@ -33,7 +33,29 @@ class ExpectationHandler(Handler):
 
 
 class ExpectationsReport:
-    def to_expectation_suite(self, suite_name=None, handler=None):
+    def to_expectation_suite(self,
+                             suite_name=None,
+                             data_context=None,
+                             save_suite=True,
+                             run_validation=True,
+                             build_data_docs=True,
+                             handler=None,
+                             ):
+        """
+        All parameters default to True to make it easier to access the full functionality of Great Expectations out of
+        the box.
+        Args:
+            suite_name: The name of your expectation suite
+            data_context: A user-specified data context
+            save_suite: Boolean to determine whether to save the suite to .json as part of the method
+            run_validation: Boolean to determine whether to run validation as part of the method
+            build_data_docs: Boolean to determine whether to build data docs, save the .html file, and open data docs in
+                your browser
+            handler: The handler to use for building expectation
+
+        Returns:
+            An ExpectationSuite
+        """
         try:
             import great_expectations as ge
         except ImportError:
@@ -50,9 +72,12 @@ class ExpectationsReport:
             handler = ExpectationHandler(ProfilingTypeSet())
 
         # Obtain the ge context and create the expectation suite
-        context = ge.data_context.DataContext()
-        suite = context.create_expectation_suite(suite_name, overwrite_existing=True)
-        context.save_expectation_suite(suite)
+        if not data_context:
+            data_context = ge.data_context.DataContext()
+
+        suite = data_context.create_expectation_suite(suite_name, overwrite_existing=True)
+        if save_suite:
+            data_context.save_expectation_suite(suite)
 
         # Instantiate an in-memory pandas dataset
         batch = ge.dataset.PandasDataset(self.df, expectation_suite=suite)
@@ -64,35 +89,24 @@ class ExpectationsReport:
         for name, variable_summary in summary["variables"].items():
             handler.handle(variable_summary["type"], name, variable_summary, batch)
 
-        return batch.get_expectation_suite()
+        if run_validation:
+            batch = ge.dataset.PandasDataset(self.df, expectation_suite=suite)
 
-    def to_expectations_with_validation_operator(
-        self, suite_name=None, handler=None, build_data_docs=True
-    ):
-        try:
-            import great_expectations as ge
-        except ImportError:
-            raise ImportError(
-                "Please install great expectations before using the expectation functionality"
+            results = data_context.run_validation_operator(
+                "action_list_operator", assets_to_validate=[batch]
             )
+            validation_result_identifier = results.list_validation_result_identifiers()[0]
 
-        context = ge.data_context.DataContext()
+            # Write expectations and open data docs
 
-        suite = self.to_expectation_suite(suite_name, handler)
+            if build_data_docs:
+                data_context.save_expectation_suite(suite)
+                data_context.build_data_docs()
+                data_context.open_data_docs(validation_result_identifier)
 
-        # Instantiate an in-memory pandas dataset
-        batch = ge.dataset.PandasDataset(self.df, expectation_suite=suite)
+        if build_data_docs and not run_validation:
+            data_context.save_expectation_suite(suite)
+            data_context.build_data_docs()
+            data_context.open_data_docs()
 
-        # This validation operator works with great_expectations < 0.12 API, and will need migrating with new style
-        # batches and validator
-        results = context.run_validation_operator(
-            "action_list_operator", assets_to_validate=[batch]
-        )
-        validation_result_identifier = results.list_validation_result_identifiers()[0]
-
-        # Write expectations and open data docs
-        context.save_expectation_suite(suite)
-
-        if build_data_docs:
-            context.build_data_docs()
-            context.open_data_docs(validation_result_identifier)
+        return batch.get_expectation_suite()


### PR DESCRIPTION
After some discussion with @spbail, we though it made sense to have just one `to_expectation_suite` method, with parameters for saving suites, running validations, and building data docs. We combined them and updated the examples to match.