### PR TITLE
Fixing empty suite issue

### DIFF
--- a/src/pandas_profiling/expectations_report.py
+++ b/src/pandas_profiling/expectations_report.py
@@ -92,6 +92,10 @@ class ExpectationsReport:
         for name, variable_summary in summary["variables"].items():
             handler.handle(variable_summary["type"], name, variable_summary, batch)
 
+        # We don't actually update the suite object on the batch in place, so need
+        # to get the populated suite from the batch
+        suite = batch.get_expectation_suite()
+
         if run_validation:
             batch = ge.dataset.PandasDataset(self.df, expectation_suite=suite)
 


### PR DESCRIPTION
This is a workaround for a known issue: whenever you add expectations to a batch, the suite object that's part of the batch isn't actually modified in place. We're updating `suite` with the populated expectation suite from the batch before using it in the rest of the function.