### PR TITLE
build: Move ipywidgets to extras

### DIFF
--- a/docsrc/source/pages/changelog/v2_12_0.rst
+++ b/docsrc/source/pages/changelog/v2_12_0.rst
@@ -27,4 +27,4 @@ Changelog v2.12.0
 
 ⬆️ Dependencies
 ^^^^^^^^^^^^^^^^^^
--
+- The `ipywidgets` dependency was moved to the `[notebook]` extra, so most of Jupyter will not be installed alongside this package by default.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,4 @@ tangled-up-in-unicode>=0.0.6
 requests>=2.24.0
 # Progress bar
 tqdm>=4.48.2
-# Jupyter notebook
-ipywidgets>=7.5.1
 seaborn>=0.10.1

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,11 @@ setup(
     python_requires=">=3.6",
     install_requires=requirements,
     extras_require={
-        "notebook": ["jupyter-client>=6.0.0", "jupyter-core>=4.6.3"],
+        "notebook": [
+            "jupyter-client>=6.0.0",
+            "jupyter-core>=4.6.3",
+            "ipywidgets>=7.5.1",
+        ],
     },
     package_data={
         "pandas_profiling": ["py.typed"],


### PR DESCRIPTION
This will allow installing the package without installing all of Jupyter, if you only want HTML output.

There's a PR over at PhiK's repo to get rid of the numba/llvmlite hard dependency; an earlier revision of this PR also took care of making PhiK optional. https://github.com/KaveIO/PhiK/pull/17