### PR TITLE
Reverted the fastparquet dependency replacement of pyarrow

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@ codecov
 pytest-mypy
 pytest-cov
 nbval
-fastparquet==0.5.0
+pyarrow
 flake8
 check-manifest>=0.41
 twine>=3.1.1

--- a/tests/issues/test_issue147.py
+++ b/tests/issues/test_issue147.py
@@ -13,7 +13,7 @@ def test_issue147(get_data_file):
         "https://github.com/Teradata/kylo/raw/master/samples/sample-data/parquet/userdata2.parquet",
     )
 
-    df = pd.read_parquet(str(file_name), engine="fastparquet")
+    df = pd.read_parquet(str(file_name), engine="pyarrow")
     report = ProfileReport(df, title="PyArrow with Pandas Parquet Backend")
     html = report.to_html()
     assert type(html) == str


### PR DESCRIPTION
The dependency to `fastparquet ` is not required anymore since `pyarrow` is available in python3.8 now.

Also see https://github.com/pandas-profiling/pandas-profiling/pull/670#issuecomment-786772204 