### PR TITLE
build: Upgrade phik

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ htmlmin>=0.1.12
 # Missing values
 missingno>=0.4.2
 # Correlations
-phik>=0.10.0
+phik>=0.11.1
 # Text analysis
 tangled-up-in-unicode>=0.0.6
 # Examples


### PR DESCRIPTION
This drops the hard dependency on numba.

Follows up on #708
Refs KaveIO/PhiK#17