### PR TITLE
Removed dead link to dark theme config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ A set of options is available in order to adapt the report generated.
 * `progress_bar` (`bool`): If True, `pandas-profiling` will display a progress bar.
 * `infer_dtypes` (`bool`): When `True` (default) the `dtype` of variables are inferred using `visions` using the typeset logic (for instance a column that has integers stored as string will be analyzed as if being numeric).
 
-More settings can be found in the [default configuration file](https://github.com/pandas-profiling/pandas-profiling/blob/master/src/pandas_profiling/config_default.yaml), [minimal configuration file](https://github.com/pandas-profiling/pandas-profiling/blob/master/src/pandas_profiling/config_minimal.yaml) and [dark themed configuration file](https://github.com/pandas-profiling/pandas-profiling/blob/master/src/pandas_profiling/config_dark.yaml).
+More settings can be found in the [default configuration file](https://github.com/pandas-profiling/pandas-profiling/blob/master/src/pandas_profiling/config_default.yaml) and [minimal configuration file](https://github.com/pandas-profiling/pandas-profiling/blob/master/src/pandas_profiling/config_minimal.yaml).
 
 You find the configuration docs on the advanced usage page [here](https://pandas-profiling.github.io/pandas-profiling/docs/master/rtd/pages/advanced_usage.html)
 


### PR DESCRIPTION
I've removed the dead link to the dark themed configuration file that no longer exists. 

Closes #734 

I tried to run make docs but I've struggled to create an environment that works in - I created an empty conda environment with Python 3.9 and pip then ran:

1. python setup.py install
2. pip install -r requirements-dev.txt
3. pip install -r requirements-test.txt
4. make docs

But make always errors out looking for README.md in the root packages dir. I'm more a conda package person so sorry if I'm doing anything dumb here.