### PR TITLE
ci: migrate dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
https://docs.github.com/en/code-security/supply-chain-security/upgrading-from-dependabotcom-to-github-native-dependabot