### PR TITLE
Bugfix: change Settings to child of BaseModel

### DIFF
--- a/docsrc/source/pages/advanced_usage.rst
+++ b/docsrc/source/pages/advanced_usage.rst
@@ -223,8 +223,8 @@ You can use the ``report.invalidate_cache()`` method for this.
 Passing the values "rendering" only resets previously rendered reports (HTML, JSON or widgets).
 Alternatively "report" also resets the report structure.
 
-Read config from envrionment
------------------------------
+Read config from environment
+----------------------------
 Any profile report config setting can also be read in from environment variables.
 
 For example:
@@ -233,13 +233,13 @@ For example:
 
     from pandas_profiling import ProfileReport
 
-    profile = ProfileReport(df, title="My Custome Pandas Profiling Report")
+    profile = ProfileReport(df, title="My Custom Pandas Profiling Report")
 
-is equivalent to setting the title as an enviroment variable
+is equivalent to setting the title as an environment variable
 
-.. code-block::
+.. code-block:: console
 
-    $ export title="My Custome Pandas Profiling Report"
+    export PROFILE_TITLE="My Custom Pandas Profiling Report"
 
 and running
 

--- a/docsrc/source/pages/advanced_usage.rst
+++ b/docsrc/source/pages/advanced_usage.rst
@@ -222,3 +222,34 @@ If the config for only the HTML report is changed (for instance you would like t
 You can use the ``report.invalidate_cache()`` method for this.
 Passing the values "rendering" only resets previously rendered reports (HTML, JSON or widgets).
 Alternatively "report" also resets the report structure.
+
+Read config from envrionment
+-----------------------------
+Any profile report config setting can also be read in from environment variables.
+
+For example:
+
+.. code-block:: python
+
+    from pandas_profiling import ProfileReport
+
+    profile = ProfileReport(
+      df,
+      title="My Custome Pandas Profiling Report"
+    )
+
+is equivalent to setting the title as an enviroment variable
+
+.. code-block::
+
+    $ export title="My Custome Pandas Profiling Report"
+
+and running
+
+.. code-block:: python
+
+    from pandas_profiling import ProfileReport
+
+    profile = ProfileReport(
+      df
+    )

--- a/src/pandas_profiling/config.py
+++ b/src/pandas_profiling/config.py
@@ -2,7 +2,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, BaseSettings, Field
+from pydantic import BaseModel, Field
 
 
 def _merge_dictionaries(dict1: dict, dict2: dict) -> dict:

--- a/src/pandas_profiling/config.py
+++ b/src/pandas_profiling/config.py
@@ -231,7 +231,7 @@ class Report(BaseModel):
     precision: int = 10
 
 
-class Settings(BaseSettings):
+class Settings(BaseModel):
     # Title of the document
     title: str = "Pandas Profiling Report"
 

--- a/src/pandas_profiling/config.py
+++ b/src/pandas_profiling/config.py
@@ -232,6 +232,10 @@ class Report(BaseModel):
 
 
 class Settings(BaseSettings):
+    # Default prefix to avoid collisions with environment variables
+    class Config:
+        env_prefix = "profile_"
+
     # Title of the document
     title: str = "Pandas Profiling Report"
 
@@ -296,7 +300,6 @@ class Settings(BaseSettings):
 
 
 class Config:
-    env_prefix = "profile_"
     arg_groups: Dict[str, Any] = {
         "sensitive": {
             "samples": None,

--- a/src/pandas_profiling/config.py
+++ b/src/pandas_profiling/config.py
@@ -2,7 +2,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, BaseSettings, Field
 
 
 def _merge_dictionaries(dict1: dict, dict2: dict) -> dict:
@@ -231,7 +231,7 @@ class Report(BaseModel):
     precision: int = 10
 
 
-class Settings(BaseModel):
+class Settings(BaseSettings):
     # Title of the document
     title: str = "Pandas Profiling Report"
 
@@ -296,6 +296,7 @@ class Settings(BaseModel):
 
 
 class Config:
+    env_prefix = "profile_"
     arg_groups: Dict[str, Any] = {
         "sensitive": {
             "samples": None,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -25,8 +25,8 @@ def test_config_shorthands():
 
 
 def test_config_env(monkeypatch):
-    monkeypatch.set_env("PROFILE_TITLE", "Testing Title")
-    monkeypatch.set_env("PROFILE_PLOT", '{"dpi": 1000}')
+    monkeypatch.setenv("PROFILE_TITLE", "Testing Title")
+    monkeypatch.setenv("PROFILE_PLOT", '{"dpi": 1000}')
 
     r = ProfileReport()
     assert r.config.title == "Testing Title"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -22,3 +22,12 @@ def test_config_shorthands():
     assert r.config.duplicates.head == 0
     assert not r.config.correlations["spearman"].calculate
     assert not r.config.missing_diagrams["bar"]
+    
+    
+def test_config_env(monkeypatch):
+    monkeypatch.set_env("PROFILE_TITLE", "Testing Title")
+    monkeypatch.set_env("PROFILE_PLOT", '{"dpi": 1000}')
+    
+    r = ProfileReport()
+    assert r.config.title == "Testing Title"
+    assert r.config.plot.dpi == 1000

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -22,12 +22,12 @@ def test_config_shorthands():
     assert r.config.duplicates.head == 0
     assert not r.config.correlations["spearman"].calculate
     assert not r.config.missing_diagrams["bar"]
-    
-    
+
+
 def test_config_env(monkeypatch):
     monkeypatch.set_env("PROFILE_TITLE", "Testing Title")
     monkeypatch.set_env("PROFILE_PLOT", '{"dpi": 1000}')
-    
+
     r = ProfileReport()
     assert r.config.title == "Testing Title"
     assert r.config.plot.dpi == 1000


### PR DESCRIPTION
Fixes Issue #785 by changing The parent class of `Settings` in config.py to `BaseModel`.

When running
```profile = ProfileReport(df)```

I get the following error
```
~/github/pandas-profiling/src/pandas_profiling/profile_report.py in __init__(self, df, minimal, explorative, sensitive, dark_mode, orange_mode, sample, config_file, lazy, typeset, summarizer, config, **kwargs)
     78             raise ValueError("Can init a not-lazy ProfileReport with no DataFrame")
     79
---> 80         report_config: Settings = Settings() if config is None else config
     81
     82         if config_file is not None and minimal:

~/.pyenv/versions/3.7.9/envs/pandas-profiling-debug/lib/python3.7/site-packages/pydantic/env_settings.cpython-37m-darwin.so in pydantic.env_settings.BaseSettings.__init__()

~/.pyenv/versions/3.7.9/envs/pandas-profiling-debug/lib/python3.7/site-packages/pydantic/main.cpython-37m-darwin.so in pydantic.main.BaseModel.__init__()

ValidationError: 1 validation error for Settings
plot
  value is not a valid dict (type=type_error.dict)
  ```
which is fixed if we switch the parent class of the config.py class `Settings` to the pydantic `BaseModel` instead of `BaseSettings`.
  