### PR TITLE
#864 - Fix Extreme Values Sub-Tab Titles

### DIFF
--- a/src/pandas_profiling/report/structure/variables/render_count.py
+++ b/src/pandas_profiling/report/structure/variables/render_count.py
@@ -123,13 +123,13 @@ def render_count(config: Settings, summary: dict) -> dict:
         [
             FrequencyTable(
                 template_variables["firstn_expanded"],
-                name="Minimum 5 values",
+                name=f"Minimum {config.n_extreme_obs} values",
                 anchor_id="firstn",
                 redact=False,
             ),
             FrequencyTable(
                 template_variables["lastn_expanded"],
-                name="Maximum 5 values",
+                name=f"Maximum {config.n_extreme_obs} values",
                 anchor_id="lastn",
                 redact=False,
             ),

--- a/src/pandas_profiling/report/structure/variables/render_real.py
+++ b/src/pandas_profiling/report/structure/variables/render_real.py
@@ -250,13 +250,13 @@ def render_real(config: Settings, summary: dict) -> dict:
         [
             FrequencyTable(
                 template_variables["firstn_expanded"],
-                name="Minimum 5 values",
+                name=f"Minimum {config.n_extreme_obs} values",
                 anchor_id=f"{varid}firstn",
                 redact=False,
             ),
             FrequencyTable(
                 template_variables["lastn_expanded"],
-                name="Maximum 5 values",
+                name=f"Maximum {config.n_extreme_obs} values",
                 anchor_id=f"{varid}lastn",
                 redact=False,
             ),

--- a/tests/issues/test_issue864.py
+++ b/tests/issues/test_issue864.py
@@ -1,0 +1,37 @@
+"""
+Test for issue 864:
+https://github.com/pandas-profiling/pandas-profiling/issues/
+
+Validate Extreme Values sub-tabs state the correct number of extreme values shown.
+"""
+import pandas as pd
+import random
+import fnmatch
+
+from pandas_profiling import ProfileReport
+
+
+def test_issue864():
+    def random_list(n):
+        return [random.randrange(0, 100) for _ in range(0, n)]
+
+    df = pd.DataFrame({'a': random_list(30)})
+
+    profile = ProfileReport(df)
+
+    def test_with_value(n_extreme_obs):
+        """Generate HTML and validate the tabs contain the proper tab titles."""
+        profile.config.n_extreme_obs = n_extreme_obs
+        profile.invalidate_cache()
+
+        reg_min = f'*<a href=* aria-controls=* role=tab data-toggle=tab>Minimum {n_extreme_obs} values</a>*'
+        reg_max = f'*<a href=* aria-controls=* role=tab data-toggle=tab>Maximum {n_extreme_obs} values</a>*'
+        
+        html = profile.to_html()
+
+        assert fnmatch.fnmatch(html, reg_min)
+        assert fnmatch.fnmatch(html, reg_max)
+
+    test_with_value(5)
+    test_with_value(10)
+    test_with_value(12)


### PR DESCRIPTION
When generating HTML, the tabs under Extreme Values are now generated using the config value `n_extreme_obs`.

Closes #864.