### PR TITLE
ENH:  issue #863 If defined, stop words to be ignored in word count table 

### DIFF
--- a/src/pandas_profiling/config.py
+++ b/src/pandas_profiling/config.py
@@ -57,6 +57,7 @@ class CatVars(BaseModel):
     coerce_str_to_date: bool = False
     redact: bool = False
     histogram_largest: int = 50
+    stop_words: List[str] = []
 
 
 class BoolVars(BaseModel):

--- a/src/pandas_profiling/config_default.yaml
+++ b/src/pandas_profiling/config_default.yaml
@@ -49,6 +49,7 @@ vars:
         coerce_str_to_date: false
         redact: false
         histogram_largest: 50
+        stop_words: []
     bool:
         n_obs: 3
         # string to boolean mapping dict

--- a/src/pandas_profiling/config_minimal.yaml
+++ b/src/pandas_profiling/config_minimal.yaml
@@ -49,6 +49,8 @@ vars:
         coerce_str_to_date: false
         redact: false
         histogram_largest: 10
+        stop_words: []
+
     bool:
         n_obs: 3
         # string to boolean mapping dict

--- a/src/pandas_profiling/model/pandas/describe_categorical_pandas.py
+++ b/src/pandas_profiling/model/pandas/describe_categorical_pandas.py
@@ -1,7 +1,7 @@
 import contextlib
 import string
 from collections import Counter
-from typing import Tuple
+from typing import List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -134,8 +134,21 @@ def unicode_summary_vc(vc: pd.Series) -> dict:
     return summary
 
 
-def word_summary_vc(vc: pd.Series) -> dict:
-    # TODO: preprocess (stopwords)
+def word_summary_vc(vc: pd.Series, stop_words: List[str] = []) -> dict:
+    """Count the number of occurrences of each individual word across
+    all lines of the data Series, then sort from the word with the most
+    occurrences to the word with the least occurrences. If a list of
+    stop words is given, they will be ignored.
+
+    Args:
+        vc: Series containing all unique categories as index and their
+            frequency as value. Sorted from the most frequent down.
+        stop_words: List of stop words to ignore, empty by default.
+
+    Returns:
+        A dict containing the results as a Series with unique words as
+        index and the computed frequency as value
+    """
     # TODO: configurable lowercase/punctuation etc.
     # TODO: remove punctuation in words
 
@@ -147,6 +160,12 @@ def word_summary_vc(vc: pd.Series) -> dict:
     word_counts = word_counts[word_counts.index.notnull()]
     word_counts = word_counts.groupby(level=0, sort=False).sum()
     word_counts = word_counts.sort_values(ascending=False)
+
+    # Remove stop words
+    if len(stop_words) > 0:
+        stop_words = [x.lower() for x in stop_words]
+        word_counts = word_counts.loc[~word_counts.index.isin(stop_words)]
+
     return {"word_counts": word_counts}
 
 
@@ -218,6 +237,6 @@ def pandas_describe_categorical_1d(
         summary.update(unicode_summary_vc(value_counts))
 
     if config.vars.cat.words:
-        summary.update(word_summary_vc(value_counts))
+        summary.update(word_summary_vc(value_counts, config.vars.cat.stop_words))
 
     return config, series, summary

--- a/tests/unit/test_pandas/test_describe_categorical_pandas.py
+++ b/tests/unit/test_pandas/test_describe_categorical_pandas.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import pytest
+
+from pandas_profiling.model.pandas.describe_categorical_pandas import word_summary_vc
+
+value_counts_w_words = pd.Series(index=["The dog", "is hungry"], data=[2, 1])
+
+
+def test_word_summary_vc():
+    pd.testing.assert_series_equal(
+        word_summary_vc(vc=value_counts_w_words)["word_counts"],
+        pd.Series(index=["the", "dog", "is", "hungry"], data=[2, 2, 1, 1]),
+    )
+
+
+@pytest.mark.parametrize("stop_words", [["The"], ["the", "a"]])
+def test_word_summary_vc_with_stop_words(stop_words):
+    pd.testing.assert_series_equal(
+        word_summary_vc(vc=value_counts_w_words, stop_words=stop_words)["word_counts"],
+        pd.Series(index=["dog", "is", "hungry"], data=[2, 1, 1]),
+    )


### PR DESCRIPTION
Stop words can be defined by changing the config of the ProfileReport:
-> profile.config.vars.cat.stop_words = [the, to]

The stop words are then ignored in the word count and frequency table : 

![image](https://user-images.githubusercontent.com/18192364/141181132-921ea00d-f8d5-4b0a-a91f-c2b815c9b56c.png)

My changes have no impact on the character count and frequency table.