### PR TITLE
feat: ignore maptypes and explicitly warn user

### DIFF
--- a/src/pandas_profiling/model/spark/table_spark.py
+++ b/src/pandas_profiling/model/spark/table_spark.py
@@ -40,11 +40,15 @@ def spark_get_table_stats(
             if series_summary["n_missing"] == n:
                 table_stats["n_vars_all_missing"] += 1
 
-    table_stats["p_cells_missing"] = (
-        table_stats["n_cells_missing"] / (result.n * result.n_var)
-        if result.n > 0
-        else 0
-    )
+    # without this check we'll get a div by zero error
+    if result.n * result.n_var > 0:
+        table_stats["p_cells_missing"] = (
+            table_stats["n_cells_missing"] / (result.n * result.n_var)
+            if result.n > 0
+            else 0
+        )
+    else:
+        table_stats["p_cells_missing"] = 0
 
     result.p_cells_missing = table_stats["p_cells_missing"]
     result.n_cells_missing = table_stats["n_cells_missing"]

--- a/tests/backends/spark_backend/test_descriptions_spark.py
+++ b/tests/backends/spark_backend/test_descriptions_spark.py
@@ -78,6 +78,7 @@ def describe_data():
             [1, 2],
         ],
         "mixed": [1, 2, "a", 4, 5, 6, 7, 8, 9],
+        "dict": [{"hello": "there", "General": "Kenobi"}],
     }
     return data
 
@@ -352,6 +353,7 @@ def expected_results():
             "n_missing": 0,
             "p_missing": 0,
         },
+        "dict": {},
     }
 
 
@@ -372,6 +374,7 @@ def expected_results():
         "bool_01_with_nan",
         "list",
         "mixed",
+        "dict",
     ],
 )
 def test_describe_spark_df(


### PR DESCRIPTION
Enable maptypes to be ignored explicitly by spark so that profiling works properly