### PR TITLE
Losen jupyter-client dependency for Colab

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     install_requires=requirements,
     extras_require={
         "notebook": [
-            "jupyter-client>=6.0.0",
+            "jupyter-client>=5.3.4",
             "jupyter-core>=4.6.3",
             "ipywidgets>=7.5.1",
         ],


### PR DESCRIPTION
This was bumped in https://github.com/pandas-profiling/pandas-profiling/commit/3d6f9040eec2023caa1f5561772e67115d554666 at the time where the dep was `==`, a bit arbitrarily I guess.

Google Colab still uses jupyter-client 5.3.5, and it still works as far as I could test (ProfileReport)