### PR TITLE
fix: fix skewness and kurtosis errors

### DIFF
--- a/src/pandas_profiling/model/alerts.py
+++ b/src/pandas_profiling/model/alerts.py
@@ -329,7 +329,7 @@ def alert_value(value: float) -> bool:
 
 
 def skewness_alert(v: float, threshold: int) -> bool:
-    return not np.isnan(v) and (v < (-1 * threshold) or v > threshold)
+    return not pd.isnull(v) and (v < (-1 * threshold) or v > threshold)
 
 
 def type_date_alert(series: pd.Series) -> bool:

--- a/src/pandas_profiling/report/structure/variables/render_real.py
+++ b/src/pandas_profiling/report/structure/variables/render_real.py
@@ -196,25 +196,12 @@ def render_real(config: Settings, summary: dict) -> dict:
             "value": fmt_numeric(summary["cv"], precision=config.report.precision),
         },
         {
-            "name": "Kurtosis",
-            "value": fmt_numeric(
-                summary["kurtosis"], precision=config.report.precision
-            ),
-        },
-        {
             "name": "Mean",
             "value": fmt_numeric(summary["mean"], precision=config.report.precision),
         },
         {
             "name": "Median Absolute Deviation (MAD)",
             "value": fmt_numeric(summary["mad"], precision=config.report.precision),
-        },
-        {
-            "name": "Skewness",
-            "value": fmt_numeric(
-                summary["skewness"], precision=config.report.precision
-            ),
-            "class": "alert" if "skewness" in summary["alert_fields"] else "",
         },
         {
             "name": "Sum",
@@ -233,6 +220,27 @@ def render_real(config: Settings, summary: dict) -> dict:
             {
                 "name": "Monotonicity",
                 "value": fmt_monotonic(summary["monotonic"]),
+            }
+        )
+
+    if summary["kurtosis"] is not None:
+        stats.append(
+            {
+                "name": "Kurtosis",
+                "value": fmt_numeric(
+                    summary["kurtosis"], precision=config.report.precision
+                ),
+            }
+        )
+
+    if summary["skewness"] is not None:
+        stats.append(
+            {
+                "name": "Skewness",
+                "value": fmt_numeric(
+                    summary["skewness"], precision=config.report.precision
+                ),
+                "class": "alert" if "skewness" in summary["alert_fields"] else "",
             }
         )
 


### PR DESCRIPTION
Spark kurtosis and skewness functions changed
the output from np.nan to None, which caused
some errors. Using pd.isnull instead of np.isnan
enables the handling of both None and np.nan
better. Also make kurtosis and skewness fields
optional.