### PR TITLE
Feature: Custom pie plot colors, fixes #571

### DIFF
--- a/docsrc/source/pages/advanced_usage.rst
+++ b/docsrc/source/pages/advanced_usage.rst
@@ -165,6 +165,8 @@ It's possible to disable certain groups of features through configuration shorth
 
 Customise plots
 ---------------
+Plot rendering options
+^^^^^^^^^^^^^^^^^^^^^^
 A way how to pass arguments to the underlying matplotlib is to use the ``plot`` argument. It is possible to change the default format of images to png (default svg) using the key-pair ``image_format: "png"`` and also the resolution of the image using ``dpi: 800``.
 An example would be:
 
@@ -176,6 +178,29 @@ An example would be:
         explorative=True,
         plot={"dpi": 200, "image_format": "png"},
     )
+
+Pie charts
+^^^^^^^^^^
+Pie charts are used to plot the frequency of categories in categorical (or boolean) features.
+
+By default, a feature is considered as categorical if it does not have more than 10 distinct values.
+This threshold can be configured with the ``plot.pie.max_unique`` setting.
+
+.. code-block:: python
+    profile = ProfileReport(pd.DataFrame(["a", "b", "c"]))
+    # Changing the *max_unique* threshold to 2 will make feature non-categorical
+    profile.config.plot.pie.max_unique = 2
+
+If the feature is not considered as categorical, the pie chart will not be displayed.
+
+All pie charts can therefore be removed by setting: ``plot.pie.max_unique = 0``.
+
+The pie chart colors can be configured to any `recognised matplotlib colour <https://matplotlib.org/stable/tutorials/colors/colors.html>`_
+with the ``plot.pie.colors`` setting. 
+
+.. code-block:: python
+    profile = ProfileReport(pd.DataFrame([1, 2, 3]))
+    profile.config.plot.pie.colors = ["gold", "b", "#FF796C"]
 
 Customise correlation matrix
 -----------------------------

--- a/src/pandas_profiling/config.py
+++ b/src/pandas_profiling/config.py
@@ -133,6 +133,11 @@ class Pie(BaseModel):
     # display a pie chart if the number of distinct values is smaller or equal (set to 0 to disable)
     max_unique: int = 10
 
+    # Colors shoud be a list of matplotlib recognised strings:
+    # --> https://matplotlib.org/stable/tutorials/colors/colors.html
+    # --> matplotlib defaults are used by default
+    colors: Optional[List[str]] = None
+
 
 class Plot(BaseModel):
     missing: MissingPlot = MissingPlot()

--- a/src/pandas_profiling/config_default.yaml
+++ b/src/pandas_profiling/config_default.yaml
@@ -138,6 +138,7 @@ plot:
     pie:
         # display a pie chart if the number of distinct values is smaller or equal (set to 0 to disable)
         max_unique: 10
+        colors: null # use null for default or give a list of matplotlib recognised strings      
 
     histogram:
         x_axis_labels: true

--- a/src/pandas_profiling/config_minimal.yaml
+++ b/src/pandas_profiling/config_minimal.yaml
@@ -140,6 +140,7 @@ plot:
     pie:
       # display a pie chart if the number of distinct values is smaller or equal (set to 0 to disable)
       max_unique: 0
+      colors: null # use null for default or give a list of matplotlib recognised strings
 
     histogram:
         x_axis_labels: true

--- a/src/pandas_profiling/visualisation/plot.py
+++ b/src/pandas_profiling/visualisation/plot.py
@@ -302,6 +302,19 @@ def scatter_pairwise(
 def pie_plot(
     config: Settings, data: pd.Series, legend_kws: Optional[dict] = None
 ) -> str:
+    """Generate pie plot showing proportions of categorical and boolean
+    variables. Modify colors by setting 'config.plot.pie.colors' to a
+    list of valid matplotib colors.
+    https://matplotlib.org/stable/tutorials/colors/colors.html
+
+    Args:
+        config (Settings): a config
+        data (pd.Series): the categories and their frequency
+        legend_kws (Optional[dict], optional): Defaults to None.
+
+    Returns:
+        str: pie plot encoded in text
+    """
     if legend_kws is None:
         legend_kws = {}
 
@@ -313,7 +326,12 @@ def pie_plot(
 
         return my_autopct
 
-    wedges, _, _ = plt.pie(data, autopct=make_autopct(data), textprops={"color": "w"})
+    wedges, _, _ = plt.pie(
+        data,
+        autopct=make_autopct(data),
+        textprops={"color": "w"},
+        colors=config.plot.pie.colors,
+    )
     plt.legend(wedges, data.index.values, **legend_kws)
 
     return plot_360_n0sc0pe(config)

--- a/tests/unit/test_visualizations.py
+++ b/tests/unit/test_visualizations.py
@@ -1,0 +1,26 @@
+"""
+Test for the visualization functionality  
+"""
+import pandas as pd
+
+from pandas_profiling import ProfileReport
+from pandas_profiling.utils.cache import cache_file
+
+test_data = pd.DataFrame([1, 2, 3])
+
+matplotlib_colors = {"gold": "#ffd700", "b": "#0000ff", "#FF796C": "#ff796c"}
+
+def test_report_with_custom_pie_chart_colors():
+    profile = ProfileReport(df=test_data,
+        progress_bar=False,
+        samples=None,
+        correlations=None,
+        missing_diagrams=None,
+        duplicates=None,
+        interactions=None,
+    )
+    profile.config.plot.pie.colors = list(matplotlib_colors.keys())
+    
+    html_report = profile.to_html()
+    for c, hex_code in matplotlib_colors.items():
+        assert "fill: {}".format(hex_code) in html_report, f"Missing color code of {c}"


### PR DESCRIPTION
Allows for the colours of the pie chart to set to any matplotlib compatible colour string.
profile.config.plot.pie.colorscolors= ["gold", "b", "#FF796C"]