### PR TITLE
Quick fix for HTML rendering ith custom typeset

### DIFF
--- a/src/pandas_profiling/report/structure/report.py
+++ b/src/pandas_profiling/report/structure/report.py
@@ -96,10 +96,11 @@ def render_variables_section(config: Settings, dataframe_summary: dict) -> list:
         }
 
         template_variables.update(summary)
-
+        
         # Per type template variables
+        render_map_type = render_map.get(summary["type"], "Unsupported")
         template_variables.update(
-            render_map[summary["type"]](config, template_variables)
+            render_map_type(config, template_variables)
         )
 
         # Ignore these


### PR DESCRIPTION
PR related to issue #906 I raised a week ago.

This is a simple fix, that will not block the exectuion of the rendering. All types that are not in the render map are treated as unsupported and the HTML will only show a basic rendering.


