### PR TITLE
fix: replace np.NaN with np.nan for NumPy 2.0 compatibility

### DIFF
--- a/src/ydata_profiling/model/spark/describe_numeric_spark.py
+++ b/src/ydata_profiling/model/spark/describe_numeric_spark.py
@@ -105,7 +105,7 @@ def describe_numeric_1d_spark(
     summary["p_negative"] = summary["n_negative"] / summary["n"]
     summary["range"] = summary["max"] - summary["min"]
     summary["iqr"] = summary["75%"] - summary["25%"]
-    summary["cv"] = summary["std"] / summary["mean"] if summary["mean"] else np.NaN
+    summary["cv"] = summary["std"] / summary["mean"] if summary["mean"] else np.nan
     summary["p_zeros"] = summary["n_zeros"] / summary["n"]
     summary["p_infinite"] = summary["n_infinite"] / summary["n"]
 


### PR DESCRIPTION
Addresses the `AttributeError` caused by the removal of `np.NaN` in NumPy 2.0.

This PR replaces all deprecated `np.NaN` instances with the correct `np.nan` throughout the `src` directory, in `src/ydata_profiling/model/spark/describe_numeric_spark.py`.

This update ensures compatibility with NumPy >= 2.0.

Fixes #1770