### PR TITLE
fix: Allow NoneType values to be string formatted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+uv.lock
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -85,3 +86,6 @@ docsrc/source/pages/api/_autosummary/
 # User created
 VERSION
 version.py
+
+# local java/spark sdk environment files
+.sdkmanrc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ dev = [
     "sphinx-autodoc-typehints>=1.10.3",
     "sphinx-multiversion>=0.2.3",
     "autodoc_pydantic",
+    "standard-imghdr"
 ]
 
 docs = [

--- a/src/ydata_profiling/report/formatters.py
+++ b/src/ydata_profiling/report/formatters.py
@@ -245,13 +245,16 @@ def fmt_numeric(value: float, precision: int = 10) -> str:
     Returns:
         The numeric value with the given precision.
     """
-    fmtted = f"{{:.{precision}g}}".format(value)
-    for v in ["e+", "e-"]:
-        if v in fmtted:
-            sign = "-" if v in "e-" else ""
-            fmtted = fmtted.replace(v, " × 10<sup>") + "</sup>"
-            fmtted = fmtted.replace("<sup>0", "<sup>")
-            fmtted = fmtted.replace("<sup>", f"<sup>{sign}")
+    if value is None:
+        fmtted = "N/A"
+    else:
+        fmtted = f"{{:.{precision}g}}".format(value)
+        for v in ["e+", "e-"]:
+            if v in fmtted:
+                sign = "-" if v in "e-" else ""
+                fmtted = fmtted.replace(v, " × 10<sup>") + "</sup>"
+                fmtted = fmtted.replace("<sup>0", "<sup>")
+                fmtted = fmtted.replace("<sup>", f"<sup>{sign}")
 
     return fmtted
 

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -83,6 +83,7 @@ def test_fmt_array(array, threshold, expected):
         (1e20, 10, "1 × 10<sup>20</sup>"),
         (1e-20, 10, "1 × 10<sup>-20</sup>"),
         (1e8, 3, "1 × 10<sup>8</sup>"),
+        (None, 3, "N/A"),
     ],
 )
 def test_fmt_numeric(value, precision, expected):


### PR DESCRIPTION
This change addresses issue #1723 (https://github.com/ydataai/ydata-profiling/issues/1723). 

It implements a "N/A" string as the default when formatting NoneType values.